### PR TITLE
Add ticket backlog (T00–T15)

### DIFF
--- a/thoughts/shared/tickets/T00-verify-head-builds.md
+++ b/thoughts/shared/tickets/T00-verify-head-builds.md
@@ -1,0 +1,33 @@
+---
+id: T00
+title: Verify HEAD builds and tests pass at current implementation level
+priority: high
+phase: infra
+status: open
+blocks: all other tickets
+---
+
+## Summary
+
+Before any new work begins, confirm the repository builds and tests pass cleanly at HEAD. This is the baseline. Identify and fix any regressions or broken state so subsequent tickets start from a known-good point.
+
+## Motivation
+
+The research identified several potential issues (stale Kotlin example build, commented-out toolchain config, partial implementations). Before writing new code it's important to know what "working at current level" means.
+
+## Acceptance Criteria
+
+- [ ] `bazel build //...` passes from the repo root (all library + compiler targets)
+- [ ] `bazel test //...` passes from the repo root (all tests, including placeholder tests)
+- [ ] `bazel build //...` passes from `examples/io_grpc/bazel_build_java/`
+- [ ] `bazel test //...` passes from `examples/io_grpc/bazel_build_java/`
+- [ ] `bazel build //...` passes from `examples/io_grpc/bazel_build_kt/` — **or** this failure is documented as a known issue tracked in T01
+- [ ] CI passes (or CI failures are all pre-existing and documented)
+- [ ] Any newly discovered build/test failures are either fixed here or filed as separate tickets
+
+## Implementation Notes
+
+- The Kotlin example (`bazel_build_kt`) is suspected broken due to stale Bzlmod dep references (`@grpc-kotlin`, `@io_bazel_rules_kotlin`). If confirmed broken, document the failure here and track the fix in T01 rather than blocking T00 on it.
+- The root `bazel test //...` will run placeholder tests (empty bodies) — these should pass trivially.
+- The two real APT processor tests (`DaggerGrpcAPTProcessorTest`) must pass.
+- The KSP processor test is known-commented-out (tracked in T08); its placeholder should still compile and the empty test method should pass.

--- a/thoughts/shared/tickets/T01-fix-kotlin-example-bzlmod.md
+++ b/thoughts/shared/tickets/T01-fix-kotlin-example-bzlmod.md
@@ -1,0 +1,36 @@
+---
+id: T01
+title: Fix Kotlin example Bzlmod migration
+priority: high
+phase: infra
+status: open
+blocked_by: T00
+---
+
+## Summary
+
+The `examples/io_grpc/bazel_build_kt` example uses stale WORKSPACE-style repository names (`@io_bazel_rules_kotlin`, `@grpc-kotlin`) that are not declared in its `MODULE.bazel`. This example is likely broken under the current Bzlmod setup.
+
+## Motivation
+
+Both examples are standalone Bazel workspaces treated as real consumer projects in CI. A broken Kotlin example means the KSP processor path is untested end-to-end in CI.
+
+## Affected Files
+
+- `examples/io_grpc/bazel_build_kt/MODULE.bazel` — missing `grpc-kotlin` bazel_dep
+- `examples/io_grpc/bazel_build_kt/proto/BUILD.bazel` — loads from `@grpc-kotlin//:kt_jvm_grpc.bzl`
+- `examples/io_grpc/bazel_build_kt/client/BUILD.bazel` — loads from `@io_bazel_rules_kotlin`
+- `examples/io_grpc/bazel_build_kt/service/armeria/BUILD.bazel` — loads from `@io_bazel_rules_kotlin`
+
+## Acceptance Criteria
+
+- [ ] `bazel build //...` passes from `examples/io_grpc/bazel_build_kt/`
+- [ ] `bazel test //...` passes from `examples/io_grpc/bazel_build_kt/`
+- [ ] All load statements use current Bzlmod canonical repository names (`@rules_kotlin`, not `@io_bazel_rules_kotlin`)
+- [ ] `grpc-kotlin` (or equivalent) is declared as a `bazel_dep` in the example `MODULE.bazel`, or proto/gRPC generation is handled via an approach consistent with the root MODULE.bazel
+
+## Implementation Notes
+
+- The root `MODULE.bazel` does not declare `grpc-kotlin` as a dep. Check if `grpc-java` + `rules_proto_grpc_java` (already declared) can generate the Kotlin stubs, or if `grpc-kotlin` needs to be added.
+- `@io_bazel_rules_kotlin` → `@rules_kotlin` is a straightforward rename for all load statements.
+- Consider whether the proto compilation pipeline should be unified between the Java and Kotlin examples (both could use `java_grpc_library` + `java_proto_library` since the Kotlin note in the test BUILD files says "kotlin proto generation relies on the java anyway").

--- a/thoughts/shared/tickets/T02-pin-kotlin-toolchain.md
+++ b/thoughts/shared/tickets/T02-pin-kotlin-toolchain.md
@@ -1,0 +1,38 @@
+---
+id: T02
+title: Pin Kotlin toolchain version explicitly
+priority: medium
+phase: infra
+status: open
+blocked_by: T00
+---
+
+## Summary
+
+The root `BUILD.bazel` has a commented-out `define_kt_toolchain` call. As a result, the build uses the default Kotlin toolchain bundled with `rules_kotlin 2.1.0` with no explicit language/API version or JVM target pinned.
+
+## Motivation
+
+Unpinned toolchain means:
+- Kotlin language version can silently change when `rules_kotlin` is upgraded
+- JVM bytecode target is unspecified, which can cause compatibility issues between modules
+- Reproducibility is weakened
+
+## Affected Files
+
+- `BUILD.bazel:3-8` — commented-out `define_kt_toolchain` invocation
+- `examples/io_grpc/bazel_build_java/BUILD.bazel` — may need a toolchain too
+- `examples/io_grpc/bazel_build_kt/BUILD.bazel` — may need a toolchain too
+
+## Acceptance Criteria
+
+- [ ] `define_kt_toolchain` is uncommented and configured in the root `BUILD.bazel`
+- [ ] Explicit Kotlin language version, API version, and JVM target are set
+- [ ] Both example sub-workspaces also pin the same toolchain (or inherit it if possible)
+- [ ] `bazel build //...` and `bazel test //...` continue to pass
+
+## Implementation Notes
+
+- Decide on Kotlin language/API version: given KSP pin of `1.9.0-1.0.12`, the Kotlin version should be 1.9.x. Consider whether upgrading to Kotlin 2.x is also in scope here or a separate ticket (note: T08 mentions kotlin-compile-testing is broken with Kotlin 2).
+- JVM target: JVM 11 or 17 are reasonable choices for a 2024+ project.
+- `rules_kotlin` 2.1.0 toolchain configuration reference: https://github.com/bazelbuild/rules_kotlin

--- a/thoughts/shared/tickets/T03-proto-version-skew.md
+++ b/thoughts/shared/tickets/T03-proto-version-skew.md
@@ -1,0 +1,33 @@
+---
+id: T03
+title: Resolve protobuf version skew between Bazel module and Maven
+priority: low
+phase: infra
+status: open
+blocked_by: T00
+---
+
+## Summary
+
+There are two independent protobuf version pins in the build:
+- `protobuf` Bazel module: `23.1` (used as `@protobuf//java/core`)
+- Maven artifact: `com.google.protobuf:protobuf-java:4.29.3` (used as `@maven//:com_google_protobuf_protobuf_java`)
+
+These are different versions of the same library appearing on the classpath in different parts of the build.
+
+## Motivation
+
+Version skew between protobuf runtime JARs can cause subtle runtime failures (e.g., generated message classes compiled against one version failing to interoperate with runtime from another). While the build may work today, this is a latent correctness risk.
+
+## Acceptance Criteria
+
+- [ ] Protobuf Java library is sourced from a single consistent version across the build
+- [ ] Either all targets use `@protobuf//java/core` (Bazel module, update to a recent version) or all targets use `@maven//:com_google_protobuf_protobuf_java` (Maven, 4.29.3)
+- [ ] No mixing of protobuf versions on any single compilation classpath
+- [ ] `bazel build //...` and `bazel test //...` continue to pass
+
+## Implementation Notes
+
+- Protobuf Bazel module v23.1 corresponds to approximately protobuf-java 3.23.1 (old 3.x naming). The Maven pin of 4.29.3 is a much newer edition.
+- Prefer the Maven artifact (4.29.3) for consistency with other Maven-resolved deps, and update the Bazel module to a version whose Java core matches 4.29.3 — or avoid using `@protobuf//java/core` directly and source everything through Maven.
+- Audit all BUILD files for `@protobuf//java/core` usages and replace with the appropriate `@maven//` label.

--- a/thoughts/shared/tickets/T04-design-module-generation.md
+++ b/thoughts/shared/tickets/T04-design-module-generation.md
@@ -1,0 +1,55 @@
+---
+id: T04
+title: Design the generated module and subcomponent shape (ADR)
+priority: high
+phase: codegen
+status: open
+blocked_by: T00
+blocks: T05, T06, T07
+---
+
+## Summary
+
+Before implementing module generation (T05/T06), nail down the exact shape of what the processors will generate. The two hand-written files in the examples — `GrpcCallScopeGraph` and `GrpcHandlersModule` — are marked `@Generated("to be generated")` but their exact generated form needs design decisions resolved first.
+
+## Motivation
+
+Several open questions affect the generated API surface. Answering them up front avoids rework in T05/T06/T07.
+
+## Open Design Questions
+
+### 1. Should `GrpcCallScopeGraph.Supplier` be a library interface in `api/`?
+
+The `Supplier` nested interface is always the same shape: `fun callScope(): GrpcCallScopeGraph` (or its equivalent). If it's part of the runtime API rather than generated, users can implement it directly in their `ApplicationGraph` component without depending on any generated type. This avoids a circular dependency between the generated subcomponent and the module that uses it.
+
+**Options:**
+- A: Generate `Supplier` as a nested interface inside the generated `GrpcCallScopeGraph`
+- B: Define `GrpcCallScopeGraph.Supplier` (or a renamed equivalent) as a library interface in `api/`
+
+### 2. Should `GrpcCallScopeGraphModule` be generated?
+
+It's trivially always `@Module(includes = [GrpcCallContext.Module::class])`. Generating it removes one more hand-written file.
+
+### 3. What is the generated package for the module and subcomponent?
+
+Options: same package as the annotated handler class(es), a fixed package derived from the root package, or a configurable annotation parameter.
+
+### 4. How are multiple handlers in different packages handled?
+
+If `HelloWorldService` and `WhateverService` are in different packages, where does the single generated `GrpcHandlersModule` (which references both adapter classes) live?
+
+### 5. Should `ApplicationGraphModule` (self-binding) be part of the generated output or documented as user-written?
+
+The `ApplicationGraphModule` that binds `ApplicationGraph` as `GrpcCallScopeGraph.Supplier` is currently hand-written. Generating it would require the processor to know about the application component, which it doesn't (and shouldn't). Document as user-written, or find an alternative approach (e.g., `@BindsInstance` on the component builder).
+
+## Acceptance Criteria
+
+- [ ] ADR document written (can be this file, updated, or a separate `thoughts/shared/adr/` entry)
+- [ ] All five questions above answered with a clear decision and rationale
+- [ ] Expected generated output for a two-handler example is written out as a "golden" code snippet (this becomes the test fixture for T05/T06)
+- [ ] T05 and T06 can proceed with a clear spec
+
+## Implementation Notes
+
+- The existing hand-written `GrpcCallScopeGraph.kt` and `GrpcHandlersModule.kt` in `examples/io_grpc/bazel_build_kt/` are the reference starting point.
+- The `@Generated("to be generated")` marker on those files was placed intentionally as a breadcrumb.

--- a/thoughts/shared/tickets/T05-ksp-module-generation.md
+++ b/thoughts/shared/tickets/T05-ksp-module-generation.md
@@ -1,0 +1,42 @@
+---
+id: T05
+title: Implement KSP module generation (GrpcCallScopeGraph + GrpcHandlersModule)
+priority: high
+phase: codegen
+status: open
+blocked_by: T04, T07
+---
+
+## Summary
+
+Implement the `generateModule` function in the KSP processor so it generates the two remaining boilerplate files: `GrpcCallScopeGraph` (the Dagger `@Subcomponent`) and `GrpcHandlersModule` (the `@Module` with `@IntoSet` bindings).
+
+Currently `module_generator.kt:5-8` only logs and does nothing.
+
+## Affected Files
+
+- `io_grpc/compiler/ksp/src/main/kotlin/…/module_generator.kt` — implement this
+- `io_grpc/compiler/ksp/src/test/kotlin/…/DaggerGrpcSymbolProcessorTest.kt` — add test for module output (after T08 unblocks KSP tests)
+- `examples/io_grpc/bazel_build_kt/` — update to remove hand-written boilerplate once generation works (tracked in T14)
+
+## Acceptance Criteria
+
+- [ ] For a set of `@GrpcServiceHandler`-annotated classes, the KSP processor generates a `GrpcCallScopeGraph.kt` file containing:
+  - `@Subcomponent(modules = [GrpcCallScopeGraphModule::class]) @GrpcCallScope interface GrpcCallScopeGraph`
+  - One provision method per handler (e.g. `fun helloWorld(): HelloWorldService`)
+  - A nested `Supplier` interface (or reference to a library-defined one — per T04 decision)
+- [ ] The processor generates a `GrpcHandlersModule.kt` file containing:
+  - `@Module object GrpcHandlersModule` (or `@Module abstract class`)
+  - One `@Provides @IntoSet fun …(): BindableService` per handler, constructing `<Name>Adapter { supplier.callScope().<name>() }`
+  - The `GrpcCallScopeGraph.Supplier` injected as a constructor param (or via `@Provides` from the app graph)
+- [ ] Optionally: generates `GrpcCallScopeGraphModule.kt` (`@Module(includes = [GrpcCallContext.Module::class])`)
+- [ ] The Kotlin example (`bazel_build_kt`) builds with the generated files replacing the hand-written ones
+- [ ] A test verifies the generated module and subcomponent output (golden file or structural assertion)
+
+## Implementation Notes
+
+- Use KotlinPoet's `FileSpec`/`TypeSpec`/`FunSpec` — same approach as `adapterGenerator.kt`.
+- The `generateModule` function already receives `List<HandlerMetadata>` — all the info needed is available.
+- `codeGenerator.createNewFile(Dependencies(false, *sourceFiles), packageName, fileName)` is the KSP output API.
+- The generated `Supplier` factory method name needs a consistent convention (e.g. always `callScope()`).
+- Consider the multi-package case (handlers in different packages) — see T04.

--- a/thoughts/shared/tickets/T06-apt-module-generation.md
+++ b/thoughts/shared/tickets/T06-apt-module-generation.md
@@ -1,0 +1,40 @@
+---
+id: T06
+title: Implement APT module generation (Java GrpcCallScopeGraph + GrpcHandlersModule)
+priority: high
+phase: codegen
+status: open
+blocked_by: T04, T07
+---
+
+## Summary
+
+Implement Java module generation in the APT processor. The call to `env.generateModule(handlerMetadatas)` is commented out in `DaggerGrpcAPTProcessor.kt:48-51`. Un-comment it and implement the generation using JavaPoet.
+
+## Affected Files
+
+- `io_grpc/compiler/apt/src/main/kotlin/…/DaggerGrpcAPTProcessor.kt:48-51` — uncomment the call
+- `io_grpc/compiler/apt/src/main/kotlin/…/AdapterGenerator.kt` — add module generation (or create `ModuleGenerator.kt`)
+- `io_grpc/compiler/apt/src/test/kotlin/…/DaggerGrpcAPTProcessorTest.kt` — add test for module output
+- `examples/io_grpc/bazel_build_java/` — update to remove hand-written boilerplate once generation works (T14)
+
+## Acceptance Criteria
+
+- [ ] For a set of `@GrpcServiceHandler`-annotated classes, the APT processor generates a `GrpcCallScopeGraph.java` file containing:
+  - `@Subcomponent(modules = {GrpcCallScopeGraphModule.class}) @GrpcCallScope interface GrpcCallScopeGraph`
+  - One provision method per handler
+  - A nested `Supplier` interface (or reference to a library-defined one — per T04 decision)
+- [ ] The processor generates a `GrpcHandlersModule.java` file containing:
+  - `@Module abstract class GrpcHandlersModule` (or equivalent)
+  - One `@Provides @IntoSet static BindableService` method per handler, constructing `new <Name>Adapter(() -> supplier.callScope().<name>())` (or using `Callable`)
+- [ ] Optionally: generates `GrpcCallScopeGraphModule.java`
+- [ ] The Java example (`bazel_build_java`) builds with the generated files replacing the hand-written ones
+- [ ] A test verifies the generated module and subcomponent output
+
+## Implementation Notes
+
+- The Java adapter uses `Callable<AsyncService>` rather than a Kotlin lambda — the module's binding lambda must match: `() -> supplier.callScope().helloWorld()` as a `Callable`.
+- JavaPoet's `MethodSpec`, `TypeSpec`, `JavaFile` — same pattern as `AdapterGenerator.kt`.
+- The `HandlerMetadata` list is available from the APT processing loop; same data as KSP gets.
+- Ensure `generates_api = 1` on the `java_plugin` in `io_grpc/compiler/apt/BUILD.bazel` is still correct (it is — Dagger needs to see the generated component interfaces).
+- Consider a shared `ModuleGenerator` interface/abstraction between KSP and APT, or keep them fully separate (simpler given the KotlinPoet vs JavaPoet difference).

--- a/thoughts/shared/tickets/T07-extend-ksp-apt-bridge.md
+++ b/thoughts/shared/tickets/T07-extend-ksp-apt-bridge.md
@@ -1,0 +1,39 @@
+---
+id: T07
+title: Extend ksp-apt-bridge to support module generation
+priority: medium
+phase: codegen
+status: open
+blocked_by: T04
+blocks: T05, T06
+---
+
+## Summary
+
+The `ksp-apt-bridge` currently implements only the subset of KSP interface members needed for adapter generation. Module generation (T05/T06) will likely require additional APT bridge members to be implemented — specifically anything needed to inspect handler class annotations, supertype information, or constructor details that are not currently used.
+
+This ticket is to identify and implement those additional bridge members, driven by the requirements of T05/T06.
+
+## Currently Unimplemented (TODO) Members
+
+Key gaps in the bridge (all `TODO("Not yet implemented")`):
+
+- `APTClassDeclaration`: `superTypes`, `primaryConstructor`, `containingFile`, `isCompanionObject`, `findActuals`, `findExpects`, `getSealedSubclasses`
+- `APTFunctionDeclaration`: return type, modifiers, type parameters, annotations, body
+- `APTPropertyDeclaration`: all members
+- `APTType`: `isAssignableFrom`, `makeNullable`, `replace`, `starProjection`, `isMarkedNullable`, `isError`, `isFunctionType`
+- `APTTypeArgument`: all members
+- `APTAnnotation`: `defaultArguments`, `location`, `origin`, `parent`, `useSiteTarget`
+
+## Acceptance Criteria
+
+- [ ] All KSP bridge members needed by module generation (T05/T06) are implemented
+- [ ] Members are implemented only as needed (do not implement speculatively)
+- [ ] Existing adapter generation tests continue to pass
+- [ ] New bridge members have unit tests in `ksp-apt-bridge/src/test/` (builds on T11)
+
+## Implementation Notes
+
+- This ticket is driven by T05/T06 — implement bridge members on demand as the module generation code is written and run.
+- Most likely needed: `APTClassDeclaration.containingFile` (for dependency tracking in generated file `Dependencies`), and reading scope annotations (e.g. checking `@GrpcCallScope` is present on the handler class).
+- The bridge README notes it is not intended for general use, only for dagger-grpc's needs — keep the implementation scope minimal.

--- a/thoughts/shared/tickets/T08-unblock-ksp-tests.md
+++ b/thoughts/shared/tickets/T08-unblock-ksp-tests.md
@@ -1,0 +1,51 @@
+---
+id: T08
+title: Unblock KSP processor test (kotlin-compile-testing + Kotlin 2)
+priority: high
+phase: testing
+status: open
+blocked_by: T00
+blocks: T10
+---
+
+## Summary
+
+The KSP processor test (`DaggerGrpcSymbolProcessorTest.testHandlerGenerator`) is entirely commented out with:
+
+```kotlin
+// TODO(cgruber): Fix this, once kotlin-compile-testing works with Kotlin2.
+```
+
+The `kotlin-compile-testing-ksp` library (version 1.6.0) does not support Kotlin 2 compilation. This leaves the KSP processor path completely untested.
+
+## Affected Files
+
+- `io_grpc/compiler/ksp/src/test/kotlin/…/DaggerGrpcSymbolProcessorTest.kt:37-46` — commented-out test body
+- `MODULE.bazel` / `maven.install` — may need version bump for `kotlin-compile-testing-ksp`
+
+## Acceptance Criteria
+
+- [ ] `DaggerGrpcSymbolProcessorTest.testHandlerGenerator` runs and asserts the generated adapter output
+- [ ] The test verifies the generated Kotlin adapter matches the expected structure (analogous to `DaggerGrpcAPTProcessorTest.testSimpleCompilation`)
+- [ ] CI passes with the KSP test enabled
+
+## Implementation Notes
+
+### Option A: Upgrade kotlin-compile-testing
+- Check if a newer version of `com.github.tschuchortdev:kotlin-compile-testing-ksp` supports Kotlin 2.
+- As of early 2025, the library has had Kotlin 2 compatibility work; check https://github.com/tschuchort/kotlin-compile-testing for current status.
+- If upgrading, also update `com.github.tschuchortdev:kotlin-compile-testing` to the same version.
+
+### Option B: Use KSP's own test infrastructure
+- KSP provides `com.google.devtools.ksp:symbol-processing` test utilities.
+- More complex setup but less dependency on a third-party test library.
+
+### Option C: Pin back to Kotlin 1.9
+- If module generation (T05) requires Kotlin 2 features, this is not viable long-term.
+- Short-term fix only.
+
+**Recommendation:** Try Option A first. If kotlin-compile-testing 1.6+ has a Kotlin 2 release, update the Maven pin and uncomment the test.
+
+### Test fixture
+
+The existing `handlerSource` fixture in the test file (lines 7-33) defines a `Source1` class annotated `@GrpcServiceHandler`. It just needs the test body uncommented (with any API adjustments for the new library version) and an assertion against the generated output matching the Kotlin adapter shape.

--- a/thoughts/shared/tickets/T09-expand-apt-tests.md
+++ b/thoughts/shared/tickets/T09-expand-apt-tests.md
@@ -1,0 +1,42 @@
+---
+id: T09
+title: Expand APT processor tests
+priority: medium
+phase: testing
+status: open
+blocked_by: T00
+---
+
+## Summary
+
+The APT processor currently has two tests: `testSimpleCompilation` (single handler, happy path) and `testValidationFailAnnotationOnInterface` (error case). Expand coverage for edge cases, multi-handler scenarios, and — once T06 is done — module generation output.
+
+## Affected Files
+
+- `io_grpc/compiler/apt/src/test/kotlin/…/DaggerGrpcAPTProcessorTest.kt`
+
+## Acceptance Criteria
+
+**Error cases:**
+- [ ] Test: `@GrpcServiceHandler` with a `grpcWrapperType` that has no `AsyncService` inner interface → compilation error with a clear message
+- [ ] Test: `@GrpcServiceHandler` with a non-class `grpcWrapperType` (e.g. an interface) → error
+
+**Multi-handler:**
+- [ ] Test: two `@GrpcServiceHandler` classes in the same compilation unit → two `*Adapter` files generated, each correct
+- [ ] Test: two handlers with different package names → adapters generated in correct packages
+
+**Adapter correctness:**
+- [ ] Test: a service with multiple RPC methods → all methods are overridden in the generated adapter
+- [ ] Test: a service with zero RPC methods (edge case) → adapter still compiles
+
+**Module generation (add after T06):**
+- [ ] Test: single handler → generated `GrpcCallScopeGraph.java` matches expected shape
+- [ ] Test: single handler → generated `GrpcHandlersModule.java` matches expected shape
+- [ ] Test: two handlers → both provision methods in `GrpcCallScopeGraph`, both bindings in `GrpcHandlersModule`
+
+## Implementation Notes
+
+- Use `google-compile-testing` (`@maven//:com_google_testing_compile_compile_testing`) for all tests — same framework as existing tests.
+- The `FooServiceGrpc` test fixture (generated from `foo.proto` in the test directory) can be reused for most cases. Add a `foo2.proto` or a second service in `foo.proto` for multi-handler tests.
+- Use `JavaFileObjects.forSourceString` or `forResource` to create test inputs.
+- `Compilation.generatedSourceFiles()` returns all generated files; assert on count and content.

--- a/thoughts/shared/tickets/T10-expand-ksp-tests.md
+++ b/thoughts/shared/tickets/T10-expand-ksp-tests.md
@@ -1,0 +1,40 @@
+---
+id: T10
+title: Expand KSP processor tests
+priority: medium
+phase: testing
+status: open
+blocked_by: T08
+---
+
+## Summary
+
+Once the KSP processor test is unblocked (T08), expand it to cover the same cases as T09 for the APT path, plus KSP-specific concerns (deferred processing, incremental processing).
+
+## Affected Files
+
+- `io_grpc/compiler/ksp/src/test/kotlin/…/DaggerGrpcSymbolProcessorTest.kt`
+
+## Acceptance Criteria
+
+**Adapter generation (mirrors T09):**
+- [ ] Test: single handler → generated `*Adapter.kt` matches expected Kotlin shape (`() -> AsyncService` lambda, no try/catch)
+- [ ] Test: `@GrpcServiceHandler` on an interface → compilation error with clear message
+- [ ] Test: `grpcWrapperType` with no `AsyncService` inner interface → error
+- [ ] Test: two handlers → two adapter files generated
+- [ ] Test: service with multiple RPC methods → all methods overridden in adapter
+
+**KSP-specific:**
+- [ ] Test: deferred processing — symbol not yet resolvable in round 1 → correctly returned in `unprocessable` and resolved in round 2
+
+**Module generation (add after T05):**
+- [ ] Test: single handler → generated `GrpcCallScopeGraph.kt` matches expected shape
+- [ ] Test: single handler → generated `GrpcHandlersModule.kt` matches expected shape
+- [ ] Test: two handlers → subcomponent and module both reference both handlers
+
+## Implementation Notes
+
+- Use `kotlin-compile-testing-ksp` (once unblocked by T08).
+- The existing `handlerSource` fixture in the test file is already defined; just needs the test body restored and assertions added.
+- The `FooServiceGrpc` test fixture (from `foo.proto`) is shared between APT and KSP test dirs — reuse as-is or add a second service for multi-handler tests.
+- The generated Kotlin output uses `() -> AsyncService` (no `Callable`, no try/catch) — assertions should check for this distinction vs the Java/APT output.

--- a/thoughts/shared/tickets/T11-common-and-bridge-tests.md
+++ b/thoughts/shared/tickets/T11-common-and-bridge-tests.md
@@ -1,0 +1,42 @@
+---
+id: T11
+title: Write real tests for common/ and ksp-apt-bridge
+priority: medium
+phase: testing
+status: open
+blocked_by: T00
+---
+
+## Summary
+
+Both `CommonTest` and `ModelTest` are empty placeholders. Write real unit tests for the `Validator` (in `common/`) and the `ksp-apt-bridge` model classes.
+
+## Affected Files
+
+- `io_grpc/compiler/common/src/test/kotlin/…/CommonTest.kt` — currently `fun testFoo() {}`
+- `ksp-apt-bridge/src/test/kotlin/…/ModelTest.kt` — currently `println("foo")` only
+
+## Acceptance Criteria
+
+### Validator tests (`CommonTest.kt`)
+
+- [ ] `validateAnnotation`: returns `null` + logs error when `@GrpcServiceHandler` is absent
+- [ ] `validateGrpcClass`: returns `null` + logs error when `grpcWrapperType` can't be resolved as a class
+- [ ] `validateServiceInterface`: returns `null` + logs error when the gRPC class has no `AsyncService` inner interface
+- [ ] Happy path: all three validations pass → correct `HandlerMetadata` returned with expected `name`, `packageName`, `grpcClass`, `serviceInterface`, `adapterName`
+- [ ] `adapterName` computed property: `"HelloWorldService"` → `"HelloWorldServiceAdapter"`
+
+### ksp-apt-bridge model tests (`ModelTest.kt`)
+
+- [ ] `APTClassDeclaration.qualifiedName` and `simpleName` return correct values from a `TypeElement`
+- [ ] `APTClassDeclaration.packageName` is correctly derived from the qualified name
+- [ ] `APTClassDeclaration.classKind` maps `ElementKind.CLASS` → `ClassKind.CLASS`, `ElementKind.INTERFACE` → `ClassKind.INTERFACE`
+- [ ] `APTAnnotation.shortName` returns the simple name of the annotation type
+- [ ] `APTValueArgument.value` converts a `TypeMirror`-valued annotation argument to an `APTType` (the critical path for `grpcWrapperType`)
+- [ ] `APTLogger` routes `error()` to `Messager` with `Diagnostic.Kind.ERROR`
+
+## Implementation Notes
+
+- Testing the `Validator` requires KSP `KSClassDeclaration` instances. In the KSP test context (`kotlin-compile-testing-ksp`), these come from a real KSP processing round. Alternatively, create simple mock/stub implementations of the KSP interfaces for unit testing the validator in isolation.
+- Testing the bridge model classes requires setting up a `javax.annotation.processing` processing environment. This is straightforward with `google-compile-testing`: use `CompilationSubject` and a custom test processor that captures elements.
+- The `APTValueArgument.value` TypeMirror conversion test is the most important — it's the critical path that allows the `grpcWrapperType` class reference to flow through the bridge.

--- a/thoughts/shared/tickets/T12-example-integration-tests.md
+++ b/thoughts/shared/tickets/T12-example-integration-tests.md
@@ -1,0 +1,45 @@
+---
+id: T12
+title: Write example integration tests (start Armeria server, send real gRPC requests)
+priority: medium
+phase: testing
+status: open
+blocked_by: T00
+---
+
+## Summary
+
+Both example `ServiceTest` classes are empty placeholders. Write integration tests that start the actual Armeria gRPC server and send real gRPC requests, asserting on response content and header propagation through `GrpcCallContext`.
+
+## Affected Files
+
+- `examples/io_grpc/bazel_build_java/service/armeria/src/test/java/…/ServiceTest.java`
+- `examples/io_grpc/bazel_build_kt/service/armeria/src/test/kotlin/…/ServiceTest.kt`
+
+## Acceptance Criteria
+
+**Both examples:**
+
+- [ ] Test spins up an in-process Armeria server on a random port (use `Server.builder()...build()` and `.start().join()`)
+- [ ] `SayHello` RPC: client sends a request, asserts the response echoes the `helloText` with the `"Hello: "` prefix
+- [ ] `SayGoodbye` RPC: client sends a request, asserts the response echoes `goodbyeText` with `"Goodbye: "` prefix
+- [ ] `Whatever` RPC: client sends a request with `whatever = true`, asserts `succeeded = true` in the response
+- [ ] Header propagation: client sends a custom metadata header; service reads it via injected `GrpcCallContext`; response reflects the header value (requires a small service modification or a dedicated test endpoint)
+- [ ] Server shuts down cleanly after each test (`server.stop().join()`)
+- [ ] Test uses `@After`/`afterEach` to ensure server stops even on failure
+
+**Java example** (`ServiceTest.java`):
+- [ ] Uses Java gRPC blocking stub for simplicity
+- [ ] Uses JUnit 4 (already a dep: `junit:junit:4.13.2`)
+
+**Kotlin example** (`ServiceTest.kt`):
+- [ ] Uses Kotlin (coroutine) stub or Java blocking stub — either acceptable
+- [ ] Uses JUnit 4 (consistent with existing setup)
+
+## Implementation Notes
+
+- The `ApplicationGraph` + `ExampleServer` classes are already wired end-to-end in both examples. The test can call `ApplicationGraph.builder().build().server().setup()` to get the configured server, then `.start().join()`.
+- Alternatively, build just the server in the test without going through `ApplicationGraph`, for faster test isolation.
+- For header propagation testing: the `HelloWorldService` already reads `context.headers` and includes them in the response string. Send a custom metadata key/value pair and assert it appears in the response.
+- Use an ephemeral port: `ServerBuilder.of(0)` in Armeria picks a random available port; retrieve it with `server.activeLocalPort()`.
+- gRPC client setup: `ManagedChannelBuilder.forAddress("127.0.0.1", port).usePlaintext().build()` + the generated blocking stub.

--- a/thoughts/shared/tickets/T13-io-grpc-lib-purpose.md
+++ b/thoughts/shared/tickets/T13-io-grpc-lib-purpose.md
@@ -1,0 +1,45 @@
+---
+id: T13
+title: Define io_grpc/lib/ purpose and implement or remove
+priority: low
+phase: runtime
+status: open
+---
+
+## Summary
+
+`io_grpc/lib/` contains a single placeholder file `foo/foo.kt` with no meaningful content and no declared deps in its `BUILD.bazel`. Its intended purpose is unclear. This ticket is to make a decision and act on it.
+
+## Current State
+
+```
+io_grpc/lib/
+  BUILD.bazel        (declares kt_jvm_library with no deps, no sources globbed)
+  src/main/kotlin/
+    foo/foo.kt       (placeholder)
+```
+
+## Options
+
+### Option A: Runtime helper library
+Populate `io_grpc/lib/` with higher-level server-wiring helpers that build on `api/` and `util/armeria/` — e.g., a `DaggerGrpcServer` builder that assembles the Armeria server from a `Set<BindableService>` and automatically registers `GrpcCallContext.Interceptor`. This would reduce boilerplate in `ExampleServer`.
+
+### Option B: Fold into `api/`
+If the intended content is just additional runtime types close to the core API, move them into `api/` and delete `lib/`.
+
+### Option C: Fold into `util/armeria/`
+If the intended content is Armeria-specific, move it into `util/armeria/` and delete `lib/`.
+
+### Option D: Delete the stub
+If there was no concrete plan for `lib/`, remove it to reduce confusion.
+
+## Acceptance Criteria
+
+- [ ] A decision is made among the options above
+- [ ] `io_grpc/lib/` either has real content with real deps and a clear purpose, or is deleted
+- [ ] `bazel build //...` continues to pass
+
+## Implementation Notes
+
+- This is low priority and purely structural — no user-visible behavior change.
+- Resolving this before T05/T06 is not required, but it would be good to know if module generation output should live here vs `api/`.

--- a/thoughts/shared/tickets/T14-remove-handwritten-boilerplate.md
+++ b/thoughts/shared/tickets/T14-remove-handwritten-boilerplate.md
@@ -1,0 +1,41 @@
+---
+id: T14
+title: Remove hand-written boilerplate from examples after module generation is complete
+priority: medium
+phase: cleanup
+status: open
+blocked_by: T05, T06
+---
+
+## Summary
+
+Once T05 (KSP module generation) and T06 (APT module generation) are complete and generating `GrpcCallScopeGraph`, `GrpcHandlersModule`, and (optionally) `GrpcCallScopeGraphModule`, remove the hand-written versions of those files from both examples. The examples should then demonstrate the fully processor-driven workflow.
+
+## Affected Files
+
+**Kotlin example (`bazel_build_kt`):**
+- `…/dagger/GrpcCallScopeGraph.kt` — delete (marked `@Generated("to be generated")`)
+- `…/dagger/GrpcHandlersModule.kt` — delete (marked `@Generated("to be generated")`)
+- `…/dagger/GrpcCallScopeGraphModule.kt` — delete if now generated
+
+**Java example (`bazel_build_java`):**
+- `…/dagger/GrpcCallScopeGraph.java` — delete (marked `@Generated("to be generated")`)
+- `…/dagger/GrpcHandlersModule.java` — delete
+- `…/dagger/GrpcCallScopeGraphModule.java` — delete if now generated
+
+**Both examples:**
+- `ApplicationGraph` — update to extend/implement the generated `Supplier` type
+- `ApplicationGraphModule` — update or remove based on T04 design decisions
+
+## Acceptance Criteria
+
+- [ ] No hand-written files carry `@Generated("to be generated")` in either example
+- [ ] Both examples build end-to-end using only processor-generated subcomponent/module files
+- [ ] Both example integration tests (T12) continue to pass
+- [ ] CI passes for both examples
+
+## Implementation Notes
+
+- This ticket proves the processor output is complete and correct — if the examples don't build after deletion, it reveals gaps in T05/T06.
+- `ApplicationGraph` still needs to be hand-written by the user (it's the top-level component, which the processor has no knowledge of). Update documentation to clarify this is intentional.
+- The `ApplicationGraphModule` situation depends on the T04 design decision about `GrpcCallScopeGraph.Supplier`.

--- a/thoughts/shared/tickets/T15-integration-guide.md
+++ b/thoughts/shared/tickets/T15-integration-guide.md
@@ -1,0 +1,36 @@
+---
+id: T15
+title: Write user-facing integration guide
+priority: low
+phase: docs
+status: open
+blocked_by: T05, T06, T14
+---
+
+## Summary
+
+Write a clear, step-by-step integration guide covering both the Java (APT) and Kotlin (KSP) paths. This should be the primary onboarding document for new users of `dagger-grpc`.
+
+## Audience
+
+JVM backend developers who use Dagger 2 and gRPC and want per-call scoping without boilerplate.
+
+## Acceptance Criteria
+
+- [ ] Guide covers the Java/Bazel path (APT processor, `java_library` + plugin)
+- [ ] Guide covers the Kotlin/Bazel path (KSP processor, `kt_jvm_library` + plugin)
+- [ ] Explains: how to add `dagger-grpc` to a Bazel `MODULE.bazel`
+- [ ] Explains: how to annotate a service implementation class (`@GrpcServiceHandler`, `@GrpcCallScope`, `@Inject constructor`)
+- [ ] Explains: what the processor generates (adapter + subcomponent + module) — user doesn't have to write it
+- [ ] Explains: what the user still writes (top-level `ApplicationGraph` component, server main)
+- [ ] Explains: how to inject `GrpcCallContext` for per-call metadata access
+- [ ] Includes a minimal working example (proto → service impl → main)
+- [ ] Covers: the call-scope pattern and why it exists (1–2 paragraphs)
+- [ ] Points to the full examples in `examples/io_grpc/`
+
+## Implementation Notes
+
+- Write in `README.md` at the repo root (currently placeholder-level content), or as a structured `docs/` directory.
+- Keep the "minimal example" short enough to be readable in 5 minutes.
+- The examples (`bazel_build_java`, `bazel_build_kt`) serve as the extended reference; the guide should link to them.
+- Mention the Armeria dependency as the current server integration target; note that other integrations may be added in the future.

--- a/thoughts/shared/tickets/overview.md
+++ b/thoughts/shared/tickets/overview.md
@@ -1,0 +1,48 @@
+# Ticket Overview — dagger-grpc
+
+Source: `thoughts/shared/research/2026-03-27-codebase-overview.md`
+
+## Priority / Dependency Order
+
+```
+T00  Verify HEAD builds & tests          HIGH    (prerequisite for everything)
+  └─ T01  Fix Kotlin example Bzlmod      HIGH    (broken build)
+  └─ T08  Unblock KSP tests              HIGH    (prerequisite for KSP test work)
+  └─ T02  Pin Kotlin toolchain           MEDIUM
+  └─ T03  Proto version skew             LOW
+
+T04  Design module generation shape      HIGH    (prerequisite for T05/T06/T07)
+  └─ T07  Extend ksp-apt-bridge          MEDIUM  (prerequisite for T05/T06)
+       └─ T05  KSP module generation     HIGH    (core feature)
+       └─ T06  APT module generation     HIGH    (core feature)
+            └─ T14  Remove boilerplate   MEDIUM  (cleanup after T05+T06)
+
+T09  Expand APT processor tests          MEDIUM  (can start after T00)
+T10  Expand KSP processor tests          MEDIUM  (after T08)
+T11  common/ + ksp-apt-bridge tests      MEDIUM  (after T00)
+T12  Example integration tests           MEDIUM  (after T00)
+
+T13  Define io_grpc/lib/ purpose         LOW
+T15  User-facing integration guide       LOW     (after T05+T06)
+```
+
+## Summary Table
+
+| ID  | Title                                         | Priority | Phase        | Status |
+|-----|-----------------------------------------------|----------|--------------|--------|
+| T00 | Verify HEAD builds and tests pass             | HIGH     | infra        | open   |
+| T01 | Fix Kotlin example Bzlmod migration           | HIGH     | infra        | open   |
+| T02 | Pin Kotlin toolchain version                  | MEDIUM   | infra        | open   |
+| T03 | Resolve proto version skew                    | LOW      | infra        | open   |
+| T04 | Design generated module shape (ADR)           | HIGH     | codegen      | open   |
+| T05 | Implement KSP module generation               | HIGH     | codegen      | open   |
+| T06 | Implement APT module generation               | HIGH     | codegen      | open   |
+| T07 | Extend ksp-apt-bridge for module generation   | MEDIUM   | codegen      | open   |
+| T08 | Unblock KSP processor test (Kotlin 2)         | HIGH     | testing      | open   |
+| T09 | Expand APT processor tests                    | MEDIUM   | testing      | open   |
+| T10 | Expand KSP processor tests                    | MEDIUM   | testing      | open   |
+| T11 | Write tests for common/ and ksp-apt-bridge    | MEDIUM   | testing      | open   |
+| T12 | Write example integration tests               | MEDIUM   | testing      | open   |
+| T13 | Define io_grpc/lib/ purpose                   | LOW      | runtime      | open   |
+| T14 | Remove hand-written boilerplate from examples | MEDIUM   | cleanup      | open   |
+| T15 | Write user-facing integration guide           | LOW      | docs         | open   |


### PR DESCRIPTION
## Summary

- Adds individual ticket files T00–T15 in \`thoughts/shared/tickets/\`, covering infra, codegen, testing, and docs work
- Adds \`thoughts/shared/tickets/overview.md\` as the canonical ticket index with priority/dependency ordering

## Test plan
- [x] No code changes; verify ticket files and overview match the summary table