### PR TITLE
Mark T03 as resolved in ticket files

### DIFF
--- a/thoughts/shared/tickets/T03-proto-version-skew.md
+++ b/thoughts/shared/tickets/T03-proto-version-skew.md
@@ -3,7 +3,7 @@ id: T03
 title: Resolve protobuf version skew between Bazel module and Maven
 priority: low
 phase: infra
-status: open
+status: done
 blocked_by: T00
 ---
 
@@ -21,10 +21,18 @@ Version skew between protobuf runtime JARs can cause subtle runtime failures (e.
 
 ## Acceptance Criteria
 
-- [ ] Protobuf Java library is sourced from a single consistent version across the build
-- [ ] Either all targets use `@protobuf//java/core` (Bazel module, update to a recent version) or all targets use `@maven//:com_google_protobuf_protobuf_java` (Maven, 4.29.3)
-- [ ] No mixing of protobuf versions on any single compilation classpath
-- [ ] `bazel build //...` and `bazel test //...` continue to pass
+- [x] Protobuf Java library is sourced from a single consistent version across the build
+- [x] Either all targets use `@protobuf//java/core` (Bazel module, update to a recent version) or all targets use `@maven//:com_google_protobuf_protobuf_java` (Maven, 4.29.3)
+- [x] No mixing of protobuf versions on any single compilation classpath
+- [x] `bazel build //...` and `bazel test //...` continue to pass
+
+## Resolution
+
+Resolved in PR #15 (T03: Resolve proto version skew — grpc-java upgrade + bazelversion pins):
+- Upgraded `grpc-java` from `1.69.0` to `1.71.0` (required for Bazel 8 compatibility — `ProtoInfo` removed as a global)
+- Replaced `@protobuf//java/core` usages in the Java example's BUILD files with `@maven//:com_google_protobuf_protobuf_java`
+- Added `.bazelversion` files to both example workspaces to pin Bazel to `8.1.1` (prevents CI from using Bazel 9 which breaks grpc-kotlin)
+- All three workspaces now build cleanly with consistent protobuf 4.29.3
 
 ## Implementation Notes
 

--- a/thoughts/shared/tickets/overview.md
+++ b/thoughts/shared/tickets/overview.md
@@ -9,7 +9,7 @@ T00  Verify HEAD builds & tests          HIGH    ✅ DONE
   └─ T01  Kotlin example Bzlmod hygiene  LOW     (builds fine; stale names only)
   └─ T08  Unblock KSP tests              HIGH    (prerequisite for KSP test work)
   └─ T02  Pin Kotlin toolchain           MEDIUM
-  └─ T03  Proto version skew             LOW
+  └─ T03  Proto version skew             LOW     ✅ DONE
 
 T04  Design module generation shape      HIGH    (prerequisite for T05/T06/T07)
   └─ T07  Extend ksp-apt-bridge          MEDIUM  (prerequisite for T05/T06)
@@ -33,7 +33,7 @@ T15  User-facing integration guide       LOW     (after T05+T06)
 | T00 | Verify HEAD builds and tests pass             | HIGH     | infra        | open   |
 | T01 | Update Kotlin example to canonical Bzlmod names (hygiene) | LOW | infra | open   |
 | T02 | Pin Kotlin toolchain version                  | MEDIUM   | infra        | open   |
-| T03 | Resolve proto version skew                    | LOW      | infra        | open   |
+| T03 | Resolve proto version skew                    | LOW      | infra        | done   |
 | T04 | Design generated module shape (ADR)           | HIGH     | codegen      | open   |
 | T05 | Implement KSP module generation               | HIGH     | codegen      | open   |
 | T06 | Implement APT module generation               | HIGH     | codegen      | open   |


### PR DESCRIPTION
## Summary

- Marks T03 (proto version skew) as `done` in `T03-proto-version-skew.md` — checks all acceptance criteria, adds resolution notes
- Updates `overview.md` status from `open` to `done` in both the dependency tree and summary table

## Test plan

- [x] No code changes — ticket metadata only
- [x] Verify T03 resolution notes match what was actually done in PR #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)