### PR TITLE
Add CLAUDE.md; rename AGENT.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Before starting any non-trivial implementation work: check `thoughts/shared/tick
 
 ### overview.md is the Canonical Index
 
-`thoughts/shared/tickets/overview.md` is the single source of truth for all open and resolved work. Individual files in that directory contain full detail; `overview.md` contains the summary. **Do not maintain ticket inventories anywhere else** — other files (AGENT.md, research docs, plans) should reference `overview.md` rather than listing tickets inline.
+`thoughts/shared/tickets/overview.md` is the single source of truth for all open and resolved work. Individual files in that directory contain full detail; `overview.md` contains the summary. **Do not maintain ticket inventories anywhere else** — other files (AGENTS.md, research docs, plans) should reference `overview.md` rather than listing tickets inline.
 
 ### Keeping overview.md Current
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Claude Code Instructions
+
+Read `AGENTS.md` in full before beginning any work. All norms, conventions, architecture descriptions, and workflow rules in that file apply to this session.
+
+## Preparatory Context
+
+After reading `AGENTS.md`, load the following into context:
+
+1. **Ticket index** — read `thoughts/shared/tickets/overview.md` to understand open and resolved work before starting any non-trivial task.
+2. **Research documents** — for any task touching a relevant subsystem, read the applicable documents in `thoughts/shared/research/`. Prefer `.compressed.md` forms when present; fall back to `.md` only when the compressed form is absent or when producing human-readable output.
+3. **Active plans** — read any relevant files in `thoughts/shared/plans/` before implementing non-trivial features.
+
+## Key Rules (Summary — See AGENTS.md for Full Detail)
+
+- Use `jj` (not `git`) for all VCS operations when `.jj/` is present.
+- Use `bin/bazel` to invoke Bazel (never source `activate-hermit` manually).
+- Never push directly to `main`; all changes go through a branch/bookmark and a PR.
+- Always include `MODULE.bazel.lock` when committing `MODULE.bazel` changes.
+- Keep `thoughts/shared/tickets/overview.md` in sync with any ticket file changes.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to give Claude Code preparatory instructions: read `AGENTS.md` on session start, then load the ticket index, relevant research docs, and active plans into context
- Rename `AGENT.md` → `AGENTS.md` to match the conventional filename expected by agent tooling (Codex, Claude, etc.)

## Validation performed
- [x] N/A — Category A (prose/metadata); no build artefacts affected

## Tickets addressed
- None

## Rollback
- Delete `CLAUDE.md` and rename `AGENTS.md` back to `AGENT.md`; no runtime impact
