### PR TITLE
fix: remove internal modifier from Validator.validate()

### DIFF
--- a/io_grpc/compiler/common/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/validations.kt
+++ b/io_grpc/compiler/common/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/validations.kt
@@ -7,7 +7,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 
 class Validator(private val logger: KSPLogger) {
-  internal fun validate(clazz: KSClassDeclaration): HandlerMetadata? {
+  fun validate(clazz: KSClassDeclaration): HandlerMetadata? {
     val annotation = validateAnnotation(clazz) ?: return null
     val grpcClass = validateGrpcClass(annotation) ?: return null
     val serviceInterface = validateServiceInterface(grpcClass) ?: return null

--- a/thoughts/shared/tickets/T00-verify-head-builds.md
+++ b/thoughts/shared/tickets/T00-verify-head-builds.md
@@ -3,7 +3,7 @@ id: T00
 title: Verify HEAD builds and tests pass at current implementation level
 priority: high
 phase: infra
-status: open
+status: done
 blocks: all other tickets
 ---
 
@@ -17,13 +17,22 @@ The research identified several potential issues (stale Kotlin example build, co
 
 ## Acceptance Criteria
 
-- [ ] `bazel build //...` passes from the repo root (all library + compiler targets)
-- [ ] `bazel test //...` passes from the repo root (all tests, including placeholder tests)
-- [ ] `bazel build //...` passes from `examples/io_grpc/bazel_build_java/`
-- [ ] `bazel test //...` passes from `examples/io_grpc/bazel_build_java/`
-- [ ] `bazel build //...` passes from `examples/io_grpc/bazel_build_kt/` — **or** this failure is documented as a known issue tracked in T01
-- [ ] CI passes (or CI failures are all pre-existing and documented)
-- [ ] Any newly discovered build/test failures are either fixed here or filed as separate tickets
+- [x] `bazel build //...` passes from the repo root (all library + compiler targets)
+- [x] `bazel test //...` passes from the repo root (all tests, including placeholder tests)
+- [x] `bazel build //...` passes from `examples/io_grpc/bazel_build_java/`
+- [x] `bazel test //...` passes from `examples/io_grpc/bazel_build_java/`
+- [x] `bazel build //...` passes from `examples/io_grpc/bazel_build_kt/`
+- [x] CI passes (or CI failures are all pre-existing and documented)
+- [x] Any newly discovered build/test failures are either fixed here or filed as separate tickets
+
+## Resolution
+
+Verified 2026-04-21. All three workspaces build and test clean:
+- Root: 26 targets built, 4/4 tests pass
+- `examples/bazel_build_java/`: 10 targets built, 2/2 tests pass
+- `examples/bazel_build_kt/`: 13 targets built (no test targets)
+
+Remaining noise is pre-existing and non-blocking: protobuf module version mismatch (upstream grpc-java), kapt/Kotlin 2 alpha warning, duplicate guava/truth artifact versions from transitive deps. T08 (KSP test commented out) confirmed as a separate open ticket.
 
 ## Implementation Notes
 

--- a/thoughts/shared/tickets/overview.md
+++ b/thoughts/shared/tickets/overview.md
@@ -30,7 +30,7 @@ T15  User-facing integration guide       LOW     (after T05+T06)
 
 | ID  | Title                                         | Priority | Phase        | Status |
 |-----|-----------------------------------------------|----------|--------------|--------|
-| T00 | Verify HEAD builds and tests pass             | HIGH     | infra        | open   |
+| T00 | Verify HEAD builds and tests pass             | HIGH     | infra        | done   |
 | T01 | Update Kotlin example to canonical Bzlmod names (hygiene) | LOW | infra | open   |
 | T02 | Pin Kotlin toolchain version                  | MEDIUM   | infra        | open   |
 | T03 | Resolve proto version skew                    | LOW      | infra        | done   |


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — no parent PR

## Summary
- Removes the `internal` modifier from `Validator.validate()` in `io_grpc/compiler/common/.../validations.kt`
- `Validator` is a public class and `validate()` is its intended entry point; `internal` was an oversight that broke downstream consumers building the KSP and common modules as separate JARs
- The local Bazel build masked the bug via `associates = ["//io_grpc/compiler/common"]` in `ksp/BUILD.bazel`, which grants cross-unit `internal` access — but that linkage doesn't exist for any other build system or JAR consumer

## Validation performed
- [x] `bin/bazel test //io_grpc/... //ksp-apt-bridge/...` — all 4 tests pass
- [x] `bin/bazel build //...` (root) — clean
- [x] `bin/bazel build //...` + `bin/bazel test //...` (both example workspaces) — clean
- [ ] ansible --check passed (N/A — library repo, no ansible)
- [ ] kubectl dry-run passed (N/A — library repo, not deployed to k8s)
- [ ] sops decrypt verified (N/A — no secrets involved)

## Affected machines / services
- N/A — library change; affects downstream consumers on next release

## Deployment steps (POST-MERGE)
- N/A — no ops deployment; downstream consumers will pick up on next library release

## Tickets addressed
- Resolves T00 (`thoughts/shared/tickets/T00-verify-head-builds.md`)

## Rollback
- Revert the one-line change to `validations.kt` (add `internal` back)
