### PR TITLE
docs: add T16 and T17 distribution tickets (BCR + Maven Central)

### DIFF
--- a/thoughts/shared/tickets/T16-publish-to-bazel-central-registry.md
+++ b/thoughts/shared/tickets/T16-publish-to-bazel-central-registry.md
@@ -1,0 +1,42 @@
+---
+id: T16
+title: Publish to Bazel Central Registry
+priority: medium
+phase: distribution
+status: open
+---
+
+## Summary
+
+Publish `dagger-grpc` to the [Bazel Central Registry (BCR)](https://registry.bazel.build/) so that Bazel projects can depend on it via a standard bzlmod `bazel_dep` declaration without needing a `local_path_override` or manual `archive_override`.
+
+## Current State
+
+The module is fully bzlmod-compatible (`MODULE.bazel` present, no `WORKSPACE` required). It is not yet registered in the BCR. Consumers must currently use `local_path_override` (as the examples do) or `archive_override` pointing at a specific GitHub archive tarball.
+
+## Goals / Acceptance Criteria
+
+- [ ] A source archive (tarball) is produced for the release and its SHA-256 is recorded
+- [ ] A BCR entry is submitted to [bazelbuild/bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry) as a pull request containing:
+  - `modules/dagger-grpc/<version>/MODULE.bazel`
+  - `modules/dagger-grpc/<version>/source.json` (URL + integrity hash pointing to the release archive)
+  - `modules/dagger-grpc/metadata.json` (homepage, maintainers, yanked_versions)
+- [ ] The BCR PR passes all automated compatibility checks
+- [ ] After acceptance, `bazel_dep(name = "dagger-grpc", version = "0.1")` resolves correctly in a fresh consumer project
+- [ ] The two example workspaces are updated to use `bazel_dep` (removing `local_path_override`) as a smoke-test
+
+## Implementation Notes
+
+- BCR submission process: fork `bazelbuild/bazel-central-registry`, add the module entry, open a PR. BCR bots run compatibility checks automatically.
+- The release archive URL must be stable (GitHub release asset or equivalent) — a branch tarball URL is not suitable.
+- `source.json` integrity field uses SRI format: `sha256-<base64>`.
+- The module name in `MODULE.bazel` is already `dagger-grpc`, matching the intended BCR name.
+- Decide on a release tagging convention (e.g. `v0.1.0`) before submitting; the BCR version string must match the `version` field in `MODULE.bazel`.
+- Prerequisite: a GitHub release (tagged archive) should exist before or alongside the BCR submission. Consider whether T17 (Maven release) should be coordinated with the same release event.
+
+## References
+
+- `MODULE.bazel:7-10` — module name and version declaration
+- `examples/io_grpc/bazel_build_java/MODULE.bazel` — current `local_path_override` pattern to replace
+- `examples/io_grpc/bazel_build_kt/MODULE.bazel` — same
+- https://github.com/bazelbuild/bazel-central-registry — submission target

--- a/thoughts/shared/tickets/T17-publish-maven-artifacts.md
+++ b/thoughts/shared/tickets/T17-publish-maven-artifacts.md
@@ -1,0 +1,71 @@
+---
+id: T17
+title: Publish Maven-compatible artifacts to Maven Central
+priority: medium
+phase: distribution
+status: open
+---
+
+## Summary
+
+Publish `dagger-grpc` library JARs to Maven Central so that Gradle, Maven, and other JVM build-tool users can depend on them without using Bazel. This makes the library accessible to the majority of the JVM ecosystem.
+
+## Current State
+
+No Maven publication infrastructure exists. The project builds with Bazel and produces JARs, but there is no mechanism to produce Maven-compatible artifacts (sources JAR, Javadoc JAR, POM) or publish them to Maven Central (via Sonatype OSSRH or the Central Portal).
+
+The publishable targets are:
+- `//api` — runtime annotations and `GrpcCallContext`
+- `//io_grpc/compiler/ksp` — KSP symbol processor
+- `//io_grpc/compiler/apt` — APT annotation processor
+- `//ksp-apt-bridge` — KSP/APT bridge library (may be internal-only; decide at implementation time)
+- `//util/armeria` — Armeria integration helper (optional; depends on Armeria runtime)
+
+## Goals / Acceptance Criteria
+
+- [ ] Maven coordinates decided and documented (e.g. `com.geekinasuit:dagger-grpc-api:0.1.0`)
+- [ ] Bazel build produces per-target: binary JAR, sources JAR, Javadoc JAR, and `pom.xml`
+- [ ] Artifacts are PGP-signed (required by Maven Central)
+- [ ] CI can publish to Maven Central on tagged releases (GitHub Actions workflow)
+- [ ] Published artifacts are resolvable via standard Maven Central coordinates in a Gradle or Maven project
+- [ ] `README` or T15 integration guide documents the Maven coordinates
+
+## Implementation Notes
+
+### Artifact production from Bazel
+
+`rules_jvm_external` does not produce Maven-compatible POM files for outbound publication. Options:
+
+- **Option A: `rules_jvm_publish` or `publish_rules`** — Bazel rules designed to produce POM + JAR bundles for Maven Central. Check current maintenance status before adopting.
+- **Option B: Gradle publication alongside Bazel** — Add a minimal Gradle wrapper (`build.gradle.kts`) that depends on the Bazel-built JARs and uses the Gradle Maven Publish plugin to generate POMs and publish. Simpler tooling but two build systems.
+- **Option C: Manual POM authoring** — Write `pom.xml` templates by hand and use a Bazel `genrule` to produce the bundle. More maintenance burden but no new dependencies.
+
+Recommendation: evaluate Option A first; fall back to Option B if no well-maintained Bazel solution exists.
+
+### Maven Central registration
+
+- Register a namespace at [central.sonatype.com](https://central.sonatype.com/) (the new Central Portal) for the chosen group ID.
+- Group ID `com.geekinasuit` requires DNS or GitHub ownership verification for `geekinasuit.com` or the GitHub org.
+- PGP key must be published to a keyserver (e.g. `keys.openpgp.org`).
+
+### Coordinates proposal (to confirm)
+
+| Target | Artifact ID |
+|---|---|
+| `//api` | `dagger-grpc-api` |
+| `//io_grpc/compiler/ksp` | `dagger-grpc-ksp` |
+| `//io_grpc/compiler/apt` | `dagger-grpc-apt` |
+| `//util/armeria` | `dagger-grpc-armeria` |
+
+Group ID: `com.geekinasuit` — Version: `0.1.0`
+
+### Release coordination
+
+Consider aligning the first Maven release with the BCR submission (T16) so both distribution channels debut at the same version.
+
+## References
+
+- `MODULE.bazel:7-10` — current version (`0.1`)
+- `api/BUILD.bazel`, `io_grpc/compiler/ksp/BUILD.bazel`, `io_grpc/compiler/apt/BUILD.bazel`, `util/armeria/BUILD.bazel` — targets to publish
+- T16 — BCR publication (coordinate release timing)
+- T15 — user-facing integration guide (will document Maven coordinates once available)

--- a/thoughts/shared/tickets/overview.md
+++ b/thoughts/shared/tickets/overview.md
@@ -24,6 +24,9 @@ T12  Example integration tests           MEDIUM  (after T00)
 
 T13  Define io_grpc/lib/ purpose         LOW
 T15  User-facing integration guide       LOW     (after T05+T06)
+
+T16  Publish to Bazel Central Registry   MEDIUM  (after stable release tag)
+T17  Publish Maven artifacts             MEDIUM  (after stable release tag; coordinate with T16)
 ```
 
 ## Summary Table
@@ -46,3 +49,5 @@ T15  User-facing integration guide       LOW     (after T05+T06)
 | T13 | Define io_grpc/lib/ purpose                   | LOW      | runtime      | open   |
 | T14 | Remove hand-written boilerplate from examples | MEDIUM   | cleanup      | open   |
 | T15 | Write user-facing integration guide           | LOW      | docs         | open   |
+| T16 | Publish to Bazel Central Registry             | MEDIUM   | distribution | open   |
+| T17 | Publish Maven-compatible artifacts            | MEDIUM   | distribution | open   |


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — no parent PR

## Summary
- Adds T16: plan for publishing `dagger-grpc` to the Bazel Central Registry (BCR) so consumers can use a standard `bazel_dep` declaration
- Adds T17: plan for publishing Maven-compatible artifacts to Maven Central, covering artifact production from Bazel, PGP signing, Maven coordinates, and CI publishing
- Updates `overview.md` dependency tree and summary table with both new tickets

## Validation performed
- [ ] ansible --check passed (N/A — prose-only change)
- [ ] kubectl dry-run passed (N/A — prose-only change)
- [ ] sops decrypt verified (N/A — no secrets)

## Affected machines / services
- N/A — ticket files only; no code or config changed

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- Introduces T16 (`thoughts/shared/tickets/T16-publish-to-bazel-central-registry.md`)
- Introduces T17 (`thoughts/shared/tickets/T17-publish-maven-artifacts.md`)

## Rollback
- N/A — deleting ticket files and reverting `overview.md` is trivially reversible
