### PR TITLE
feat(T16): BCR publication infrastructure + version bump to 0.1.0

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,14 @@
+{
+  "homepage": "https://github.com/geekinasuit/dagger-grpc",
+  "maintainers": [
+    {
+      "github": "cgruber",
+      "github_user_id": 331234,
+      "name": "Christian Gruber",
+      "email": "cgruber@geekinasuit.com"
+    }
+  ],
+  "repository": ["github:geekinasuit/dagger-grpc"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/patches/examples_use_registry.patch
+++ b/.bcr/patches/examples_use_registry.patch
@@ -1,0 +1,26 @@
+--- a/examples/io_grpc/bazel_build_java/MODULE.bazel
++++ b/examples/io_grpc/bazel_build_java/MODULE.bazel
+@@ -4,10 +4,6 @@
+ )
+
+ bazel_dep(name = "dagger-grpc", version = "0.1.0")
+-local_path_override(
+-    module_name = "dagger-grpc",
+-    path = "../../..",
+-)
+
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")
+ bazel_dep(name = "rules_java", version = "8.9.0")
+--- a/examples/io_grpc/bazel_build_kt/MODULE.bazel
++++ b/examples/io_grpc/bazel_build_kt/MODULE.bazel
+@@ -4,10 +4,6 @@
+ )
+
+ bazel_dep(name = "dagger-grpc", version = "0.1.0")
+-local_path_override(
+-    module_name = "dagger-grpc",
+-    path = "../../..",
+-)
+
+ # Most of these with repo_name only are using that to support grpc-kotlin, which doesn't
+ # use bazelmod, and is depending on old names of things.

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,32 @@
+matrix:
+  platform: ["ubuntu2004"]
+  bazel: ["7.x", "8.x"]
+tasks:
+  build_library:
+    name: "Build dagger-grpc library"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "//..."
+    test_targets:
+      - "//..."
+  test_java_example:
+    name: "Java example (APT consumer)"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    bcr_test_module:
+      module_path: "examples/io_grpc/bazel_build_java"
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."
+  test_kt_example:
+    name: "Kotlin example (KSP consumer)"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    bcr_test_module:
+      module_path: "examples/io_grpc/bazel_build_kt"
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,21 @@
+name: Publish to BCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to publish (e.g. v0.1.0)"
+        required: true
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    with:
+      tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
+      registry_fork: geekinasuit/bazel-central-registry
+      attest: false
+      draft: true
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@
 ###############################################################################
 module(
     name = "dagger-grpc",
-    version = "0.1",
+    version = "0.1.0",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "fd69814250cfd707f8c27106ce7af3ef9bead5c6d7ee90b671756ae1d8fcd959",
+  "moduleFileHash": "6955675ada70c601f91f68dd0ac5e4e865221689b81b83f6ae07d1e046b7a99d",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -18,7 +18,7 @@
   "moduleDepGraph": {
     "<root>": {
       "name": "dagger-grpc",
-      "version": "0.1",
+      "version": "0.1.0",
       "key": "<root>",
       "repoName": "dagger-grpc",
       "executionPlatformsToRegister": [],
@@ -5169,6 +5169,33 @@
         }
       }
     },
+    "@@bazel_tools//tools/android:android_extensions.bzl%remote_android_tools_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "iz3RFYDcsjupaT10sdSPAhA44WL3eDYkTEnYThllj1w=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "android_tools": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "bazel_tools~remote_android_tools_extensions~android_tools",
+              "sha256": "2b661a761a735b41c41b3a78089f4fc1982626c76ddb944604ae3ff8c545d3c2",
+              "url": "https://mirror.bazel.build/bazel_android_tools/android_tools_pkg-0.30.0.tar"
+            }
+          },
+          "android_gmaven_r8": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "name": "bazel_tools~remote_android_tools_extensions~android_gmaven_r8",
+              "sha256": "57a696749695a09381a87bc2f08c3a8ed06a717a5caa3ef878a3077e0d3af19d",
+              "url": "https://maven.google.com/com/android/tools/r8/8.1.56/r8-8.1.56.jar"
+            }
+          }
+        }
+      }
+    },
     "@@bazel_tools//tools/cpp:cc_configure.bzl%cc_configure_extension": {
       "general": {
         "bzlTransitiveDigest": "O9sf6ilKWU9Veed02jG9o2HM/xgV/UAyciuFBuxrFRY=",
@@ -5241,6 +5268,1033 @@
               "urls": [
                 "https://mirror.bazel.build/bazel_coverage_output_generator/releases/coverage_output_generator-v2.6.zip"
               ]
+            }
+          }
+        }
+      }
+    },
+    "@@cel-spec~0.15.0//:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "7bwXezojTs/urFoS8mOgUBprnKht7U3q1GdWDG98Ugg=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "cel-spec~0.15.0~non_module_dependencies~com_google_googleapis",
+              "sha256": "bd8e735d881fb829751ecb1a77038dda4a8d274c45490cb9fcf004583ee10571",
+              "strip_prefix": "googleapis-07c27163ac591955d736f3057b1619ece66f5b99",
+              "urls": [
+                "https://github.com/googleapis/googleapis/archive/07c27163ac591955d736f3057b1619ece66f5b99.tar.gz"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "@@cel-spec~0.15.0//:googleapis_ext.bzl%googleapis_ext": {
+      "general": {
+        "bzlTransitiveDigest": "yun2jmsomFi3bs5bjQWXApBzqQf66zBJ39JEBYigzdc=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis_imports": {
+            "bzlFile": "@@cel-spec~0.15.0~non_module_dependencies~com_google_googleapis//:repository_rules.bzl",
+            "ruleClassName": "switched_rules",
+            "attributes": {
+              "name": "cel-spec~0.15.0~googleapis_ext~com_google_googleapis_imports",
+              "rules": {
+                "proto_library_with_info": [
+                  "",
+                  ""
+                ],
+                "moved_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_grpc_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_test": [
+                  "",
+                  ""
+                ],
+                "java_gapic_assembly_gradle_pkg": [
+                  "",
+                  ""
+                ],
+                "py_proto_library": [
+                  "",
+                  ""
+                ],
+                "py_grpc_library": [
+                  "",
+                  ""
+                ],
+                "py_gapic_library": [
+                  "",
+                  ""
+                ],
+                "py_test": [
+                  "",
+                  ""
+                ],
+                "py_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "py_import": [
+                  "",
+                  ""
+                ],
+                "go_proto_library": [
+                  "",
+                  ""
+                ],
+                "go_library": [
+                  "",
+                  ""
+                ],
+                "go_test": [
+                  "",
+                  ""
+                ],
+                "go_gapic_library": [
+                  "",
+                  ""
+                ],
+                "go_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "cc_proto_library": [
+                  "native.cc_proto_library",
+                  ""
+                ],
+                "cc_grpc_library": [
+                  "",
+                  ""
+                ],
+                "cc_gapic_library": [
+                  "",
+                  ""
+                ],
+                "php_proto_library": [
+                  "",
+                  "php_proto_library"
+                ],
+                "php_grpc_library": [
+                  "",
+                  "php_grpc_library"
+                ],
+                "php_gapic_library": [
+                  "",
+                  "php_gapic_library"
+                ],
+                "php_gapic_assembly_pkg": [
+                  "",
+                  "php_gapic_assembly_pkg"
+                ],
+                "nodejs_gapic_library": [
+                  "",
+                  "typescript_gapic_library"
+                ],
+                "nodejs_gapic_assembly_pkg": [
+                  "",
+                  "typescript_gapic_assembly_pkg"
+                ],
+                "ruby_proto_library": [
+                  "",
+                  ""
+                ],
+                "ruby_grpc_library": [
+                  "",
+                  ""
+                ],
+                "ruby_ads_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_cloud_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "csharp_proto_library": [
+                  "",
+                  ""
+                ],
+                "csharp_grpc_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "@@envoy_api~0.0.0-20241214-918efc9//bazel:repositories.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "ND4KzaEmEY8Vn9OZoHtSJW7/oMqpaUIqQranKPYVe/U=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "prometheus_metrics_model": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "envoy_api~0.0.0-20241214-918efc9~non_module_deps~prometheus_metrics_model",
+              "urls": [
+                "https://github.com/prometheus/client_model/archive/v0.6.1.tar.gz"
+              ],
+              "sha256": "b9b690bc35d80061f255faa7df7621eae39fe157179ccd78ff6409c3b004f05e",
+              "strip_prefix": "client_model-0.6.1",
+              "build_file_content": "\nload(\"@envoy_api//bazel:api_build_system.bzl\", \"api_cc_py_proto_library\")\nload(\"@io_bazel_rules_go//proto:def.bzl\", \"go_proto_library\")\n\napi_cc_py_proto_library(\n    name = \"client_model\",\n    srcs = [\n        \"io/prometheus/client/metrics.proto\",\n    ],\n    visibility = [\"//visibility:public\"],\n)\n\ngo_proto_library(\n    name = \"client_model_go_proto\",\n    importpath = \"github.com/prometheus/client_model/go\",\n    proto = \":client_model\",\n    visibility = [\"//visibility:public\"],\n)\n"
+            }
+          },
+          "envoy_toolshed": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "envoy_api~0.0.0-20241214-918efc9~non_module_deps~envoy_toolshed",
+              "urls": [
+                "https://github.com/envoyproxy/toolshed/archive/bazel-v0.2.0.tar.gz"
+              ],
+              "sha256": "ef5e95580c41f6805beec197d9a4f6683550f4bfc1e1c678449b6d205dbf000b",
+              "strip_prefix": "toolshed-bazel-v0.2.0/bazel"
+            }
+          },
+          "com_github_bufbuild_buf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "envoy_api~0.0.0-20241214-918efc9~non_module_deps~com_github_bufbuild_buf",
+              "urls": [
+                "https://github.com/bufbuild/buf/releases/download/v1.47.2/buf-Linux-x86_64.tar.gz"
+              ],
+              "sha256": "39716cfe0185df3cba21f66ec739620ffb6876c48b2da4338a8c68c290c9b116",
+              "strip_prefix": "buf",
+              "build_file_content": "\npackage(\n    default_visibility = [\"//visibility:public\"],\n)\n\nfilegroup(\n    name = \"buf\",\n    srcs = [\n        \"@com_github_bufbuild_buf//:bin/buf\",\n    ],\n    tags = [\"manual\"], # buf is downloaded as a linux binary; tagged manual to prevent build for non-linux users\n)\n"
+            }
+          }
+        }
+      }
+    },
+    "@@gazelle~0.36.0//:extensions.bzl%go_deps": {
+      "general": {
+        "bzlTransitiveDigest": "R+GCgQReNxN4WtxORwFnlNz5U23qfEJk+VqkqOUR1XE=",
+        "accumulatedFileDigests": {
+          "@@xds~0.0.0-20240423-555b57e//go:go.mod": "524700e305a2b2bf75db01766e5e412e42619321d761bc4271635b3ffa7022d4",
+          "@@cel-spec~0.15.0//:go.mod": "d36df61c421a6d812e6898d0db66d71278ad3d538144d781b243d84761b8fd0a",
+          "@@rules_go~0.50.1//:go.mod": "de22304b720f7f61350ec1c9739de6c0a1b1103fd22bfeb6e92c6c843ddc6d6e",
+          "@@protoc-gen-validate~1.0.4.bcr.2//:go.mod": "e3c86462136d999b9302e040c77a4d76b6878a7ab52dead08a70b309742d00f7",
+          "@@gazelle~0.36.0//:go.mod": "3bdf577b31bd67ce2b7bc1c438077c421395278e79b2e95e8de7d7942d0297d7",
+          "@@rules_go~0.50.1//:go.sum": "d56fdb19b21a5f12bcf625c49432371ac39c2def0f564098fbda107f7c080f40",
+          "@@xds~0.0.0-20240423-555b57e//go:go.sum": "09880212d45075c17f62c9b716875097a757d361fdb92433877a59d38998bff3",
+          "@@protoc-gen-validate~1.0.4.bcr.2//:go.sum": "b9153426198c0f8b0d9b95085083a968dc3a922ee36e709c48a51c33e7c69abd",
+          "@@cel-spec~0.15.0//:go.sum": "cabdae016fccd48b8a9d6388036fcc5abe2a40e4f1555b5519c5fb4a43ca72ad",
+          "@@gazelle~0.36.0//:go.sum": "14df932fff1ea6aa2b9ac6ad53b8acf3d1cffe44e3375e75d1c4c9d2a86d3473"
+        },
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "org_golang_x_tools_go_vcs": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_x_tools_go_vcs",
+              "importpath": "golang.org/x/tools/go/vcs",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:cOIJqWBl99H1dH5LWizPa+0ImeeJq3t3cJjaeOWUAL4=",
+              "replace": "",
+              "version": "v0.1.0-deprecated"
+            }
+          },
+          "com_github_fsnotify_fsnotify": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_fsnotify_fsnotify",
+              "importpath": "github.com/fsnotify/fsnotify",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=",
+              "replace": "",
+              "version": "v1.7.0"
+            }
+          },
+          "org_golang_google_grpc_cmd_protoc_gen_go_grpc": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+              "importpath": "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=",
+              "replace": "",
+              "version": "v1.3.0"
+            }
+          },
+          "com_github_bmatcuk_doublestar_v4": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_bmatcuk_doublestar_v4",
+              "importpath": "github.com/bmatcuk/doublestar/v4",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=",
+              "replace": "",
+              "version": "v4.6.1"
+            }
+          },
+          "com_github_pmezard_go_difflib": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_pmezard_go_difflib",
+              "importpath": "github.com/pmezard/go-difflib",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+              "replace": "",
+              "version": "v1.0.0"
+            }
+          },
+          "org_golang_x_tools": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_x_tools",
+              "importpath": "golang.org/x/tools",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:k8NLag8AGHnn+PHbl7g43CtqZAwG60vZkLqgyZgIHgQ=",
+              "replace": "",
+              "version": "v0.18.0"
+            }
+          },
+          "org_golang_x_net": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_x_net",
+              "importpath": "golang.org/x/net",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=",
+              "replace": "",
+              "version": "v0.20.0"
+            }
+          },
+          "com_github_bazelbuild_buildtools": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_bazelbuild_buildtools",
+              "importpath": "github.com/bazelbuild/buildtools",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:VNqmvOfFzn2Hrtoni8vqgXlIQ4C2Zt22fxeZ9gOOkp0=",
+              "replace": "",
+              "version": "v0.0.0-20240313121412-66c605173954"
+            }
+          },
+          "org_golang_google_genproto": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_google_genproto",
+              "importpath": "google.golang.org/genproto",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=",
+              "replace": "",
+              "version": "v0.0.0-20200526211855-cb27e3aa2013"
+            }
+          },
+          "com_github_gogo_protobuf": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_gogo_protobuf",
+              "importpath": "github.com/gogo/protobuf",
+              "build_directives": [
+                "gazelle:proto disable"
+              ],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=",
+              "replace": "",
+              "version": "v1.3.2"
+            }
+          },
+          "com_github_golang_mock": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_golang_mock",
+              "importpath": "github.com/golang/mock",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=",
+              "replace": "",
+              "version": "v1.7.0-rc.1"
+            }
+          },
+          "org_golang_x_sync": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_x_sync",
+              "importpath": "golang.org/x/sync",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=",
+              "replace": "",
+              "version": "v0.6.0"
+            }
+          },
+          "com_github_iancoleman_strcase": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_iancoleman_strcase",
+              "importpath": "github.com/iancoleman/strcase",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=",
+              "replace": "",
+              "version": "v0.3.0"
+            }
+          },
+          "org_golang_google_grpc": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_google_grpc",
+              "importpath": "google.golang.org/grpc",
+              "build_directives": [
+                "gazelle:proto disable"
+              ],
+              "build_file_generation": "on",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Z5Iec2pjwb+LEOqzpB2MR12/eKFhDPhuqW91O+4bwUk=",
+              "replace": "",
+              "version": "v1.59.0"
+            }
+          },
+          "org_golang_google_genproto_googleapis_rpc": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_google_genproto_googleapis_rpc",
+              "importpath": "google.golang.org/genproto/googleapis/rpc",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:Elxv5MwEkCI9f5SkoL6afed6NTdxaGoAo39eANBwHL8=",
+              "replace": "",
+              "version": "v0.0.0-20240521202816-d264139d666e"
+            }
+          },
+          "com_github_google_go_cmp": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_google_go_cmp",
+              "importpath": "github.com/google/go-cmp",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=",
+              "replace": "",
+              "version": "v0.6.0"
+            }
+          },
+          "org_golang_x_text": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_x_text",
+              "importpath": "golang.org/x/text",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=",
+              "replace": "",
+              "version": "v0.14.0"
+            }
+          },
+          "org_golang_google_genproto_googleapis_api": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_google_genproto_googleapis_api",
+              "importpath": "google.golang.org/genproto/googleapis/api",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:SkdGTrROJl2jRGT/Fxv5QUf9jtdKCQh4KQJXbXVLAi0=",
+              "replace": "",
+              "version": "v0.0.0-20240521202816-d264139d666e"
+            }
+          },
+          "org_golang_google_protobuf": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_google_protobuf",
+              "importpath": "google.golang.org/protobuf",
+              "build_directives": [
+                "gazelle:proto disable"
+              ],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=",
+              "replace": "",
+              "version": "v1.33.0"
+            }
+          },
+          "org_golang_x_mod": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_x_mod",
+              "importpath": "golang.org/x/mod",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=",
+              "replace": "",
+              "version": "v0.16.0"
+            }
+          },
+          "com_github_lyft_protoc_gen_star_v2": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_lyft_protoc_gen_star_v2",
+              "importpath": "github.com/lyft/protoc-gen-star/v2",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:/3+/2sWyXeMLzKd1bX+ixWKgEMsULrIivpDsuaF441o=",
+              "replace": "",
+              "version": "v2.0.3"
+            }
+          },
+          "com_github_golang_protobuf": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_golang_protobuf",
+              "importpath": "github.com/golang/protobuf",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=",
+              "replace": "",
+              "version": "v1.5.4"
+            }
+          },
+          "bazel_gazelle_go_repository_config": {
+            "bzlFile": "@@gazelle~0.36.0//internal/bzlmod:go_deps.bzl",
+            "ruleClassName": "_go_repository_config",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~bazel_gazelle_go_repository_config",
+              "importpaths": {
+                "com_github_planetscale_vtprotobuf": "github.com/planetscale/vtprotobuf",
+                "org_golang_google_protobuf": "google.golang.org/protobuf",
+                "org_golang_google_genproto_googleapis_rpc": "google.golang.org/genproto/googleapis/rpc",
+                "org_golang_google_genproto_googleapis_api": "google.golang.org/genproto/googleapis/api",
+                "com_github_golang_protobuf": "github.com/golang/protobuf",
+                "com_github_iancoleman_strcase": "github.com/iancoleman/strcase",
+                "com_github_lyft_protoc_gen_star_v2": "github.com/lyft/protoc-gen-star/v2",
+                "org_golang_x_net": "golang.org/x/net",
+                "com_github_spf13_afero": "github.com/spf13/afero",
+                "org_golang_x_mod": "golang.org/x/mod",
+                "org_golang_x_sys": "golang.org/x/sys",
+                "org_golang_x_text": "golang.org/x/text",
+                "org_golang_x_tools": "golang.org/x/tools",
+                "@cel-spec~0.15.0": "cel.dev/expr",
+                "org_golang_google_grpc": "google.golang.org/grpc",
+                "com_github_gogo_protobuf": "github.com/gogo/protobuf",
+                "com_github_golang_mock": "github.com/golang/mock",
+                "org_golang_google_genproto": "google.golang.org/genproto",
+                "org_golang_google_grpc_cmd_protoc_gen_go_grpc": "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+                "com_github_bazelbuild_buildtools": "github.com/bazelbuild/buildtools",
+                "com_github_bmatcuk_doublestar_v4": "github.com/bmatcuk/doublestar/v4",
+                "com_github_fsnotify_fsnotify": "github.com/fsnotify/fsnotify",
+                "com_github_google_go_cmp": "github.com/google/go-cmp",
+                "com_github_pmezard_go_difflib": "github.com/pmezard/go-difflib",
+                "org_golang_x_sync": "golang.org/x/sync",
+                "org_golang_x_tools_go_vcs": "golang.org/x/tools/go/vcs",
+                "@protoc-gen-validate~1.0.4.bcr.2": "github.com/envoyproxy/protoc-gen-validate",
+                "@xds~0.0.0-20240423-555b57e": "github.com/cncf/xds/go",
+                "@rules_go~0.50.1": "github.com/bazelbuild/rules_go",
+                "@gazelle~0.36.0": "github.com/bazelbuild/bazel-gazelle"
+              },
+              "module_names": {
+                "@protoc-gen-validate~1.0.4.bcr.2": "protoc-gen-validate",
+                "@xds~0.0.0-20240423-555b57e": "xds",
+                "@cel-spec~0.15.0": "cel-spec",
+                "@rules_go~0.50.1": "rules_go",
+                "@gazelle~0.36.0": "gazelle"
+              },
+              "build_naming_conventions": {},
+              "go_env": {},
+              "dep_files": []
+            }
+          },
+          "org_golang_x_sys": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~org_golang_x_sys",
+              "importpath": "golang.org/x/sys",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=",
+              "replace": "",
+              "version": "v0.18.0"
+            }
+          },
+          "com_github_planetscale_vtprotobuf": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_planetscale_vtprotobuf",
+              "importpath": "github.com/planetscale/vtprotobuf",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=",
+              "replace": "",
+              "version": "v0.6.1-0.20240319094008-0393e58bdf10"
+            }
+          },
+          "com_github_spf13_afero": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository.bzl",
+            "ruleClassName": "go_repository",
+            "attributes": {
+              "name": "gazelle~0.36.0~go_deps~com_github_spf13_afero",
+              "importpath": "github.com/spf13/afero",
+              "build_directives": [],
+              "build_file_generation": "auto",
+              "build_extra_args": [],
+              "patches": [],
+              "patch_args": [],
+              "sum": "h1:EaGW2JJh15aKOejeuJ+wpFSHnbd7GE6Wvp3TsNhb6LY=",
+              "replace": "",
+              "version": "v1.10.0"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO"
+        }
+      }
+    },
+    "@@gazelle~0.36.0//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "G93LwkxG4sA+bgruO4+zl6gy5n+IIwXoNlVnsVBN6Eg=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bazel_gazelle_is_bazel_module": {
+            "bzlFile": "@@gazelle~0.36.0//internal:is_bazel_module.bzl",
+            "ruleClassName": "is_bazel_module",
+            "attributes": {
+              "name": "gazelle~0.36.0~non_module_deps~bazel_gazelle_is_bazel_module",
+              "is_bazel_module": true
+            }
+          },
+          "bazel_gazelle_go_repository_tools": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository_tools.bzl",
+            "ruleClassName": "go_repository_tools",
+            "attributes": {
+              "name": "gazelle~0.36.0~non_module_deps~bazel_gazelle_go_repository_tools",
+              "go_cache": "@@gazelle~0.36.0~non_module_deps~bazel_gazelle_go_repository_cache//:go.env"
+            }
+          },
+          "bazel_gazelle_go_repository_cache": {
+            "bzlFile": "@@gazelle~0.36.0//internal:go_repository_cache.bzl",
+            "ruleClassName": "go_repository_cache",
+            "attributes": {
+              "name": "gazelle~0.36.0~non_module_deps~bazel_gazelle_go_repository_cache",
+              "go_sdk_name": "@rules_go~0.50.1~go_sdk~protoc-gen-validate__download_0",
+              "go_env": {}
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "useAllRepos": "NO"
+        }
+      }
+    },
+    "@@googleapis~0.0.0-20240819-fe8ba054a//:extensions.bzl%switched_rules": {
+      "general": {
+        "bzlTransitiveDigest": "vG6fuTzXD8MMvHWZEQud0MMH7eoC4GXY0va7VrFFh04=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_google_googleapis_imports": {
+            "bzlFile": "@@googleapis~0.0.0-20240819-fe8ba054a//:repository_rules.bzl",
+            "ruleClassName": "switched_rules",
+            "attributes": {
+              "name": "googleapis~0.0.0-20240819-fe8ba054a~switched_rules~com_google_googleapis_imports",
+              "rules": {
+                "proto_library_with_info": [
+                  "",
+                  ""
+                ],
+                "moved_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_proto_library": [
+                  "",
+                  ""
+                ],
+                "java_grpc_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_library": [
+                  "",
+                  ""
+                ],
+                "java_gapic_test": [
+                  "",
+                  ""
+                ],
+                "java_gapic_assembly_gradle_pkg": [
+                  "",
+                  ""
+                ],
+                "py_proto_library": [
+                  "",
+                  ""
+                ],
+                "py_grpc_library": [
+                  "",
+                  ""
+                ],
+                "py_gapic_library": [
+                  "",
+                  ""
+                ],
+                "py_test": [
+                  "",
+                  ""
+                ],
+                "py_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "py_import": [
+                  "",
+                  ""
+                ],
+                "go_proto_library": [
+                  "",
+                  ""
+                ],
+                "go_grpc_library": [
+                  "",
+                  ""
+                ],
+                "go_library": [
+                  "",
+                  ""
+                ],
+                "go_test": [
+                  "",
+                  ""
+                ],
+                "go_gapic_library": [
+                  "",
+                  ""
+                ],
+                "go_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "cc_proto_library": [
+                  "",
+                  ""
+                ],
+                "cc_grpc_library": [
+                  "",
+                  ""
+                ],
+                "cc_gapic_library": [
+                  "",
+                  ""
+                ],
+                "php_proto_library": [
+                  "",
+                  "php_proto_library"
+                ],
+                "php_grpc_library": [
+                  "",
+                  "php_grpc_library"
+                ],
+                "php_gapic_library": [
+                  "",
+                  "php_gapic_library"
+                ],
+                "php_gapic_assembly_pkg": [
+                  "",
+                  "php_gapic_assembly_pkg"
+                ],
+                "nodejs_gapic_library": [
+                  "",
+                  "typescript_gapic_library"
+                ],
+                "nodejs_gapic_assembly_pkg": [
+                  "",
+                  "typescript_gapic_assembly_pkg"
+                ],
+                "ruby_proto_library": [
+                  "",
+                  ""
+                ],
+                "ruby_grpc_library": [
+                  "",
+                  ""
+                ],
+                "ruby_ads_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_cloud_gapic_library": [
+                  "",
+                  ""
+                ],
+                "ruby_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ],
+                "csharp_proto_library": [
+                  "",
+                  ""
+                ],
+                "csharp_grpc_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_library": [
+                  "",
+                  ""
+                ],
+                "csharp_gapic_assembly_pkg": [
+                  "",
+                  ""
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "@@googletest~1.15.2//:MODULE.bazel%_repo_rules": {
+      "general": {
+        "bzlTransitiveDigest": "Ku2DI7QuocaveVVXKoPve0mW0oKDxLp2bFFkEVN+69k=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "fuchsia_sdk": {
+            "bzlFile": "@@googletest~1.15.2//:fake_fuchsia_sdk.bzl",
+            "ruleClassName": "fake_fuchsia_sdk",
+            "attributes": {
+              "name": "googletest~1.15.2~_repo_rules~fuchsia_sdk"
+            }
+          }
+        }
+      }
+    },
+    "@@grpc~1.69.0//bazel:grpc_deps.bzl%grpc_repo_deps_ext": {
+      "general": {
+        "bzlTransitiveDigest": "F9MNat43PIKLtfYFWHv3JJHR/9EoUXfrURqbxoTSpEE=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "google_cloud_cpp": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "grpc~1.69.0~grpc_repo_deps_ext~google_cloud_cpp",
+              "sha256": "7ca7f583b60d2aa1274411fed3b9fb3887119b2e84244bb3fc69ea1db819e4e5",
+              "strip_prefix": "google-cloud-cpp-2.16.0",
+              "urls": [
+                "https://storage.googleapis.com/grpc-bazel-mirror/github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.16.0.tar.gz",
+                "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.16.0.tar.gz"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "@@platforms//host:extension.bzl%host_platform": {
+      "general": {
+        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "host_platform": {
+            "bzlFile": "@@platforms//host:extension.bzl",
+            "ruleClassName": "host_platform_repo",
+            "attributes": {
+              "name": "platforms~host_platform~host_platform"
+            }
+          }
+        }
+      }
+    },
+    "@@pybind11_bazel~2.12.0//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "XNXcUVP6KHkd0ySumBXFiR80GUb/pF73SXjzI/Shja8=",
+        "accumulatedFileDigests": {
+          "@@pybind11_bazel~2.12.0//:MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        },
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "pybind11_bazel~2.12.0~internal_configure_extension~pybind11",
+              "build_file": "@@pybind11_bazel~2.12.0//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "@@rules_apple~3.5.1//apple:apple.bzl%provisioning_profile_repository_extension": {
+      "general": {
+        "bzlTransitiveDigest": "wQbXGl4hDwdESBYZ63/49qoFmwB895p7w56gPe5eZ8U=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "local_provisioning_profiles": {
+            "bzlFile": "@@rules_apple~3.5.1//apple/internal:local_provisioning_profiles.bzl",
+            "ruleClassName": "provisioning_profile_repository",
+            "attributes": {
+              "name": "rules_apple~3.5.1~provisioning_profile_repository_extension~local_provisioning_profiles"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_apple~3.5.1//apple:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "OFxy8kOoKL0R97AHnF6iqtufyqbYtnG6yU5ZcAfPHJw=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "xctestrunner": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_apple~3.5.1~non_module_deps~xctestrunner",
+              "urls": [
+                "https://github.com/google/xctestrunner/archive/b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6.tar.gz"
+              ],
+              "strip_prefix": "xctestrunner-b7698df3d435b6491b4b4c0f9fc7a63fbed5e3a6",
+              "sha256": "ae3a063c985a8633cb7eb566db21656f8db8eb9a0edb8c182312c7f0db53730d"
             }
           }
         }
@@ -5617,6 +6671,97 @@
               "exec_compatible_with": [
                 "@platforms//os:windows"
               ]
+            }
+          }
+        }
+      }
+    },
+    "@@rules_fuzzing~0.5.2//fuzzing/private:extensions.bzl%non_module_dependencies": {
+      "general": {
+        "bzlTransitiveDigest": "HM6jbwlwQ3QNdXv2gkam2AWQlkYOAaXdgHfatkk8g1o=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "bazel_skylib": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~bazel_skylib",
+              "sha256": "cd55a062e763b9349921f0f5db8c3933288dc8ba4f76dd9416aac68acee3cb94",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz",
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.5.0/bazel-skylib-1.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_fuzzing_jazzer": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~rules_fuzzing_jazzer",
+              "sha256": "ee6feb569d88962d59cb59e8a31eb9d007c82683f3ebc64955fd5b96f277eec2",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer/0.20.1/jazzer-0.20.1.jar"
+            }
+          },
+          "rules_python": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~rules_python",
+              "sha256": "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
+              "strip_prefix": "rules_python-0.28.0",
+              "url": "https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"
+            }
+          },
+          "rules_fuzzing_oss_fuzz": {
+            "bzlFile": "@@rules_fuzzing~0.5.2//fuzzing/private/oss_fuzz:repository.bzl",
+            "ruleClassName": "oss_fuzz_repository",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~rules_fuzzing_oss_fuzz"
+            }
+          },
+          "com_google_absl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~com_google_absl",
+              "urls": [
+                "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.1.zip"
+              ],
+              "strip_prefix": "abseil-cpp-20240116.1",
+              "integrity": "sha256-7capMWOvWyoYbUaHF/b+I2U6XLMaHmky8KugWvfXYuk="
+            }
+          },
+          "honggfuzz": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~honggfuzz",
+              "build_file": "@@rules_fuzzing~0.5.2//:honggfuzz.BUILD",
+              "sha256": "6b18ba13bc1f36b7b950c72d80f19ea67fbadc0ac0bb297ec89ad91f2eaa423e",
+              "url": "https://github.com/google/honggfuzz/archive/2.5.zip",
+              "strip_prefix": "honggfuzz-2.5"
+            }
+          },
+          "platforms": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~platforms",
+              "urls": [
+                "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz",
+                "https://github.com/bazelbuild/platforms/releases/download/0.0.8/platforms-0.0.8.tar.gz"
+              ],
+              "sha256": "8150406605389ececb6da07cbcb509d5637a3ab9a24bc69b1101531367d89d74"
+            }
+          },
+          "rules_fuzzing_jazzer_api": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_jar",
+            "attributes": {
+              "name": "rules_fuzzing~0.5.2~non_module_dependencies~rules_fuzzing_jazzer_api",
+              "sha256": "f5a60242bc408f7fa20fccf10d6c5c5ea1fcb3c6f44642fec5af88373ae7aa1b",
+              "url": "https://repo1.maven.org/maven2/com/code-intelligence/jazzer-api/0.20.1/jazzer-api-0.20.1.jar"
             }
           }
         }
@@ -6939,6 +8084,154 @@
             "ruleClassName": "_compatibility_proxy_repo_rule",
             "attributes": {
               "name": "rules_java~8.9.0~compatibility_proxy~compatibility_proxy"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_jvm_external~6.7//:MODULE.bazel%_repo_rules": {
+      "general": {
+        "bzlTransitiveDigest": "5N51b9xEpf2bMJAN5rd4XedkyF3mkBazoyfbR0iSAoA=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "coursier_cli": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "sha256": "8c724dc204534353ea8263ba0af624979658f7ab62395f35b04f03ce5714f330",
+              "urls": [
+                "https://github.com/coursier/coursier/releases/download/v2.1.24/coursier.jar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~coursier_cli"
+            }
+          },
+          "buildifier-linux-arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "sha256": "c22a44eee37b8927167ee6ee67573303f4e31171e7ec3a8ea021a6a660040437",
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-arm64"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~buildifier-linux-arm64"
+            }
+          },
+          "buildifier-linux-x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "sha256": "28285fe7e39ed23dc1a3a525dfcdccbc96c0034ff1d4277905d2672a71b38f13",
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-amd64"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~buildifier-linux-x86_64"
+            }
+          },
+          "buildifier-macos-arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "sha256": "d0909b645496608fd6dfc67f95d9d3b01d90736d7b8c8ec41e802cb0b7ceae7c",
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-darwin-arm64"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~buildifier-macos-arm64"
+            }
+          },
+          "buildifier-macos-x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "sha256": "687c49c318fb655970cf716eed3c7bfc9caeea4f2931a2fd36593c458de0c537",
+              "urls": [
+                "https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-darwin-amd64"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~buildifier-macos-x86_64"
+            }
+          },
+          "com.google.ar.sceneform_rendering": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "downloaded_file_path": "rendering-1.10.0.aar",
+              "sha256": "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
+              "urls": [
+                "https://dl.google.com/android/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~com.google.ar.sceneform_rendering"
+            }
+          },
+          "hamcrest_core_for_test": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "downloaded_file_path": "hamcrest-core-1.3.jar",
+              "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~hamcrest_core_for_test"
+            }
+          },
+          "hamcrest_core_srcs_for_test": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "downloaded_file_path": "hamcrest-core-1.3-sources.jar",
+              "sha256": "e223d2d8fbafd66057a8848cc94222d63c3cedd652cc48eddc0ab5c39c0f84df",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~hamcrest_core_srcs_for_test"
+            }
+          },
+          "gson_for_test": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "downloaded_file_path": "gson-2.9.0.jar",
+              "sha256": "c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~gson_for_test"
+            }
+          },
+          "junit_platform_commons_for_test": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "downloaded_file_path": "junit-platform-commons-1.8.2.jar",
+              "sha256": "d2e015fca7130e79af2f4608dc54415e4b10b592d77333decb4b1a274c185050",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.8.2/junit-platform-commons-1.8.2.jar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~junit_platform_commons_for_test"
+            }
+          },
+          "google_api_services_compute_javadoc_for_test": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "downloaded_file_path": "google-api-services-compute-v1-rev235-1.25.0-javadoc.jar",
+              "sha256": "b03be5ee8effba3bfbaae53891a9c01d70e2e3bd82ad8889d78e641b22bd76c2",
+              "urls": [
+                "https://repo1.maven.org/maven2/com/google/apis/google-api-services-compute/v1-rev235-1.25.0/google-api-services-compute-v1-rev235-1.25.0-javadoc.jar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~google_api_services_compute_javadoc_for_test"
+            }
+          },
+          "lombok_for_test": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "downloaded_file_path": "lombok-1.18.22.jar",
+              "sha256": "ecef1581411d7a82cc04281667ee0bac5d7c0a5aae74cfc38430396c91c31831",
+              "urls": [
+                "https://repo1.maven.org/maven2/org/projectlombok/lombok/1.18.22/lombok-1.18.22.jar"
+              ],
+              "name": "rules_jvm_external~6.7~_repo_rules~lombok_for_test"
             }
           }
         }
@@ -11213,6 +12506,3018 @@
         }
       }
     },
+    "@@rules_proto_grpc_java~5.0.1//:module_extensions.bzl%download_plugins": {
+      "general": {
+        "bzlTransitiveDigest": "kBrH4wadWJfagmIw9CDjibJxqYSg+JZR6SL4qW/nV1A=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "grpc_java_plugin_darwin_x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_proto_grpc_java~5.0.1~download_plugins~grpc_java_plugin_darwin_x86_64",
+              "executable": true,
+              "sha256": "dcee3d7720a92f247dbefc17288db878ad9981293db293c86a1afb6074935c53",
+              "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.65.0/protoc-gen-grpc-java-1.65.0-osx-x86_64.exe"
+            }
+          },
+          "grpc_java_plugin_linux_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_proto_grpc_java~5.0.1~download_plugins~grpc_java_plugin_linux_arm64",
+              "executable": true,
+              "sha256": "308435e80ba288b0804b3e448b9ad97500b545f801297eb7ea142db8fe81fb9c",
+              "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.65.0/protoc-gen-grpc-java-1.65.0-linux-aarch_64.exe"
+            }
+          },
+          "grpc_java_plugin_darwin_arm64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_proto_grpc_java~5.0.1~download_plugins~grpc_java_plugin_darwin_arm64",
+              "executable": true,
+              "sha256": "dcee3d7720a92f247dbefc17288db878ad9981293db293c86a1afb6074935c53",
+              "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.65.0/protoc-gen-grpc-java-1.65.0-osx-aarch_64.exe"
+            }
+          },
+          "grpc_java_plugin_windows_x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_proto_grpc_java~5.0.1~download_plugins~grpc_java_plugin_windows_x86_64",
+              "executable": true,
+              "sha256": "9d6659af976eb5ff664eb853bba25bcdf988500040227711bd87146c55241779",
+              "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.65.0/protoc-gen-grpc-java-1.65.0-windows-x86_64.exe"
+            }
+          },
+          "grpc_java_plugin_linux_x86_64": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_file",
+            "attributes": {
+              "name": "rules_proto_grpc_java~5.0.1~download_plugins~grpc_java_plugin_linux_x86_64",
+              "executable": true,
+              "sha256": "a9f9a7987be4a37c69a85e5e8885394356fd2f1a47f843c6461da4fc99f407b3",
+              "url": "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.65.0/protoc-gen-grpc-java-1.65.0-linux-x86_64.exe"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "useAllRepos": "REGULAR"
+        }
+      }
+    },
+    "@@rules_python~0.40.0//python/extensions:pip.bzl%pip": {
+      "general": {
+        "bzlTransitiveDigest": "+LzSb+1AQ8pfo8+NBtdRoDs/CQiWoNlS/acKTa9szgQ=",
+        "accumulatedFileDigests": {
+          "@@rules_fuzzing~0.5.2//fuzzing:requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
+          "@@protoc-gen-validate~1.0.4.bcr.2//python:requirements.txt": "519d7dac0ff11c4a855aaef022dc2998ece0669db3b481cdb9e5a5d88e57eb83",
+          "@@protobuf~29.1//python:requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5",
+          "@@grpc~1.69.0//:requirements.bazel.txt": "4c8c19a2a8f22108bf29feb5cc2694eb0c7e0c82ba0364df27fe5f5e4d7936e5"
+        },
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "grpc_python_dependencies_313_pyasn1_modules": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_pyasn1_modules",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "rules_fuzzing_py_deps_38_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_38_absl_py",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_8_host//:python",
+              "repo": "rules_fuzzing_py_deps_38",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "grpc_python_dependencies_312_opentelemetry_exporter_prometheus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_opentelemetry_exporter_prometheus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "opentelemetry-exporter-prometheus==0.46b0"
+            }
+          },
+          "grpc_python_dependencies_39_typing_extensions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_typing_extensions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "typing-extensions==4.9.0"
+            }
+          },
+          "rules_fuzzing_py_deps_312_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_312_absl_py",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "rules_fuzzing_py_deps_312",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "grpc_python_dependencies_311_importlib_metadata": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_importlib_metadata",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "importlib-metadata==6.11.0"
+            }
+          },
+          "grpc_python_dependencies_310_google_cloud_monitoring": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_google_cloud_monitoring",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "google-cloud-monitoring==2.16.0"
+            }
+          },
+          "grpc_python_dependencies_313_cachetools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_cachetools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "cachetools==5.3.2"
+            }
+          },
+          "pgv_pip_deps_312_astunparse": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_312_astunparse",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pgv_pip_deps_312",
+              "requirement": "astunparse==1.6.3"
+            }
+          },
+          "grpc_python_dependencies_310_zope_interface": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_zope_interface",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "zope.interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_311_opentelemetry_resourcedetector_gcp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_opentelemetry_resourcedetector_gcp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "opentelemetry-resourcedetector-gcp==1.6.0a0"
+            }
+          },
+          "grpc_python_dependencies_39_chardet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_chardet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_311_pyasn1": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_pyasn1",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "pyasn1==0.5.0"
+            }
+          },
+          "grpc_python_dependencies_313_pyasn1": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_pyasn1",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "pyasn1==0.5.0"
+            }
+          },
+          "grpc_python_dependencies_312_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_setuptools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "setuptools==44.1.1"
+            }
+          },
+          "grpc_python_dependencies_313_coverage": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_coverage",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "pip_deps_311_numpy": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_311_numpy",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pip_deps_311",
+              "requirement": "numpy<=1.26.1"
+            }
+          },
+          "grpc_python_dependencies_39_cachetools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_cachetools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "cachetools==5.3.2"
+            }
+          },
+          "grpc_python_dependencies_311_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_googleapis_common_protos",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "googleapis-common-protos==1.63.1"
+            }
+          },
+          "grpc_python_dependencies_39_zipp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_zipp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "zipp==3.17.0"
+            }
+          },
+          "grpc_python_dependencies_313_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_absl_py",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "absl-py==1.4.0"
+            }
+          },
+          "grpc_python_dependencies_312_opentelemetry_resourcedetector_gcp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_opentelemetry_resourcedetector_gcp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "opentelemetry-resourcedetector-gcp==1.6.0a0"
+            }
+          },
+          "grpc_python_dependencies_39_deprecated": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_deprecated",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "Deprecated==1.2.14"
+            }
+          },
+          "pgv_pip_deps_310_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_310_six",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pgv_pip_deps_310",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_312_greenlet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_greenlet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "pgv_pip_deps_312_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_312_protobuf",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pgv_pip_deps_312",
+              "requirement": "protobuf==5.26.0"
+            }
+          },
+          "grpc_python_dependencies_313_idna": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_idna",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_39_charset_normalizer": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_charset_normalizer",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "grpc_python_dependencies_311_zope_event": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_zope_event",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "zope.event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_39_pyasn1_modules": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_pyasn1_modules",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_311_google_cloud_trace": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_google_cloud_trace",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "google-cloud-trace==1.11.3"
+            }
+          },
+          "pgv_pip_deps_39_astunparse": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_39_astunparse",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pgv_pip_deps_39",
+              "requirement": "astunparse==1.6.3"
+            }
+          },
+          "grpc_python_dependencies_311_idna": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_idna",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_310_requests": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_requests",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_313_requests": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_requests",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_312_cachetools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_cachetools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "cachetools==5.3.2"
+            }
+          },
+          "grpc_python_dependencies_313_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_setuptools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "setuptools==44.1.1"
+            }
+          },
+          "pgv_pip_deps_313_jinja2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_313_jinja2",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "pgv_pip_deps_313",
+              "requirement": "jinja2==3.1.3"
+            }
+          },
+          "grpc_python_dependencies_39_proto_plus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_proto_plus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "proto-plus==1.22.3"
+            }
+          },
+          "grpc_python_dependencies_39_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_wheel",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "wheel==0.38.1"
+            }
+          },
+          "grpc_python_dependencies_311_coverage": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_coverage",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "pgv_pip_deps_313_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_313_six",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "pgv_pip_deps_313",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_312_urllib3": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_urllib3",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "urllib3==1.26.18"
+            }
+          },
+          "grpc_python_dependencies_313_opentelemetry_resourcedetector_gcp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_opentelemetry_resourcedetector_gcp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "opentelemetry-resourcedetector-gcp==1.6.0a0"
+            }
+          },
+          "grpc_python_dependencies_39_opencensus_context": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_opencensus_context",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "opencensus-context==0.1.3"
+            }
+          },
+          "pgv_pip_deps_311_astunparse": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_311_astunparse",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pgv_pip_deps_311",
+              "requirement": "astunparse==1.6.3"
+            }
+          },
+          "grpc_python_dependencies_313_deprecated": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_deprecated",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "Deprecated==1.2.14"
+            }
+          },
+          "grpc_python_dependencies_312_opentelemetry_sdk": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_opentelemetry_sdk",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "opentelemetry-sdk==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_311_gevent": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_gevent",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "gevent==22.08.0"
+            }
+          },
+          "grpc_python_dependencies_39_google_auth": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_google_auth",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "google-auth==2.23.4"
+            }
+          },
+          "grpc_python_dependencies_39_google_cloud_trace": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_google_cloud_trace",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "google-cloud-trace==1.11.3"
+            }
+          },
+          "grpc_python_dependencies_311_google_api_core": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_google_api_core",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "google-api-core==1.34.1"
+            }
+          },
+          "grpc_python_dependencies_313_wrapt": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_wrapt",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "wrapt==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_313_chardet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_chardet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_312_oauth2client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_oauth2client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_310_opentelemetry_resourcedetector_gcp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_opentelemetry_resourcedetector_gcp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "opentelemetry-resourcedetector-gcp==1.6.0a0"
+            }
+          },
+          "grpc_python_dependencies_313_google_cloud_monitoring": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_google_cloud_monitoring",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "google-cloud-monitoring==2.16.0"
+            }
+          },
+          "grpc_python_dependencies_312_prometheus_client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_prometheus_client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "prometheus_client==0.20.0"
+            }
+          },
+          "grpc_python_dependencies_313_cython": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_cython",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "cython==3.0.0"
+            }
+          },
+          "grpc_python_dependencies_310_opentelemetry_exporter_prometheus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_opentelemetry_exporter_prometheus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "opentelemetry-exporter-prometheus==0.46b0"
+            }
+          },
+          "grpc_python_dependencies_310_oauth2client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_oauth2client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_311_rsa": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_rsa",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "pgv_pip_deps_39_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_39_wheel",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pgv_pip_deps_39",
+              "requirement": "wheel==0.43.0"
+            }
+          },
+          "grpc_python_dependencies_39_urllib3": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_urllib3",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "urllib3==1.26.18"
+            }
+          },
+          "grpc_python_dependencies_313_importlib_metadata": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_importlib_metadata",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "importlib-metadata==6.11.0"
+            }
+          },
+          "grpc_python_dependencies_310_greenlet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_greenlet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "grpc_python_dependencies_312_zipp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_zipp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "zipp==3.17.0"
+            }
+          },
+          "pgv_pip_deps_310_validate_email": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_310_validate_email",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pgv_pip_deps_310",
+              "requirement": "validate-email==1.3"
+            }
+          },
+          "pgv_pip_deps_310_markupsafe": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_310_markupsafe",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pgv_pip_deps_310",
+              "requirement": "markupsafe==2.1.5"
+            }
+          },
+          "grpc_python_dependencies_312_opentelemetry_api": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_opentelemetry_api",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "opentelemetry-api==1.25.0"
+            }
+          },
+          "rules_fuzzing_py_deps": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps",
+              "repo_name": "rules_fuzzing_py_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "[{\"repo\":\"rules_fuzzing_py_deps_310_absl_py\",\"version\":\"3.10\"},{\"repo\":\"rules_fuzzing_py_deps_311_absl_py\",\"version\":\"3.11\"},{\"repo\":\"rules_fuzzing_py_deps_312_absl_py\",\"version\":\"3.12\"},{\"repo\":\"rules_fuzzing_py_deps_38_absl_py\",\"version\":\"3.8\"},{\"repo\":\"rules_fuzzing_py_deps_39_absl_py\",\"version\":\"3.9\"}]",
+                "six": "[{\"repo\":\"rules_fuzzing_py_deps_310_six\",\"version\":\"3.10\"},{\"repo\":\"rules_fuzzing_py_deps_311_six\",\"version\":\"3.11\"},{\"repo\":\"rules_fuzzing_py_deps_312_six\",\"version\":\"3.12\"},{\"repo\":\"rules_fuzzing_py_deps_38_six\",\"version\":\"3.8\"},{\"repo\":\"rules_fuzzing_py_deps_39_six\",\"version\":\"3.9\"}]"
+              },
+              "packages": [
+                "absl_py",
+                "six"
+              ],
+              "groups": {}
+            }
+          },
+          "pip_deps_39_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_39_setuptools",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pip_deps_39",
+              "requirement": "setuptools<=70.3.0"
+            }
+          },
+          "pip_deps": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps",
+              "repo_name": "pip_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "numpy": "[{\"repo\":\"pip_deps_310_numpy\",\"version\":\"3.10\"},{\"repo\":\"pip_deps_311_numpy\",\"version\":\"3.11\"},{\"repo\":\"pip_deps_312_numpy\",\"version\":\"3.12\"},{\"repo\":\"pip_deps_38_numpy\",\"version\":\"3.8\"},{\"repo\":\"pip_deps_39_numpy\",\"version\":\"3.9\"}]",
+                "setuptools": "[{\"repo\":\"pip_deps_310_setuptools\",\"version\":\"3.10\"},{\"repo\":\"pip_deps_311_setuptools\",\"version\":\"3.11\"},{\"repo\":\"pip_deps_312_setuptools\",\"version\":\"3.12\"},{\"repo\":\"pip_deps_38_setuptools\",\"version\":\"3.8\"},{\"repo\":\"pip_deps_39_setuptools\",\"version\":\"3.9\"}]"
+              },
+              "packages": [
+                "numpy",
+                "setuptools"
+              ],
+              "groups": {}
+            }
+          },
+          "grpc_python_dependencies_39_pyasn1": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_pyasn1",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "pyasn1==0.5.0"
+            }
+          },
+          "grpc_python_dependencies_39_opentelemetry_api": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_opentelemetry_api",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "opentelemetry-api==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_310_opentelemetry_sdk": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_opentelemetry_sdk",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "opentelemetry-sdk==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_310_prometheus_client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_prometheus_client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "prometheus_client==0.20.0"
+            }
+          },
+          "grpc_python_dependencies_311_urllib3": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_urllib3",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "urllib3==1.26.18"
+            }
+          },
+          "pip_deps_311_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_311_setuptools",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pip_deps_311",
+              "requirement": "setuptools<=70.3.0"
+            }
+          },
+          "grpc_python_dependencies_312_gevent": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_gevent",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "gevent==22.08.0"
+            }
+          },
+          "grpc_python_dependencies_310_zope_event": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_zope_event",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "zope.event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_310_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_googleapis_common_protos",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "googleapis-common-protos==1.63.1"
+            }
+          },
+          "grpc_python_dependencies_312_deprecated": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_deprecated",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "Deprecated==1.2.14"
+            }
+          },
+          "grpc_python_dependencies_39_certifi": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_certifi",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "certifi==2023.7.22"
+            }
+          },
+          "pgv_pip_deps_311_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_311_wheel",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pgv_pip_deps_311",
+              "requirement": "wheel==0.43.0"
+            }
+          },
+          "grpc_python_dependencies_312_zope_interface": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_zope_interface",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "zope.interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_312_google_cloud_trace": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_google_cloud_trace",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "google-cloud-trace==1.11.3"
+            }
+          },
+          "grpc_python_dependencies_310_idna": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_idna",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "idna==2.7"
+            }
+          },
+          "pgv_pip_deps": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps",
+              "repo_name": "pgv_pip_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "astunparse": "[{\"repo\":\"pgv_pip_deps_310_astunparse\",\"version\":\"3.10\"},{\"repo\":\"pgv_pip_deps_311_astunparse\",\"version\":\"3.11\"},{\"repo\":\"pgv_pip_deps_312_astunparse\",\"version\":\"3.12\"},{\"repo\":\"pgv_pip_deps_313_astunparse\",\"version\":\"3.13\"},{\"repo\":\"pgv_pip_deps_39_astunparse\",\"version\":\"3.9\"}]",
+                "jinja2": "[{\"repo\":\"pgv_pip_deps_310_jinja2\",\"version\":\"3.10\"},{\"repo\":\"pgv_pip_deps_311_jinja2\",\"version\":\"3.11\"},{\"repo\":\"pgv_pip_deps_312_jinja2\",\"version\":\"3.12\"},{\"repo\":\"pgv_pip_deps_313_jinja2\",\"version\":\"3.13\"},{\"repo\":\"pgv_pip_deps_39_jinja2\",\"version\":\"3.9\"}]",
+                "markupsafe": "[{\"repo\":\"pgv_pip_deps_310_markupsafe\",\"version\":\"3.10\"},{\"repo\":\"pgv_pip_deps_311_markupsafe\",\"version\":\"3.11\"},{\"repo\":\"pgv_pip_deps_312_markupsafe\",\"version\":\"3.12\"},{\"repo\":\"pgv_pip_deps_313_markupsafe\",\"version\":\"3.13\"},{\"repo\":\"pgv_pip_deps_39_markupsafe\",\"version\":\"3.9\"}]",
+                "protobuf": "[{\"repo\":\"pgv_pip_deps_310_protobuf\",\"version\":\"3.10\"},{\"repo\":\"pgv_pip_deps_311_protobuf\",\"version\":\"3.11\"},{\"repo\":\"pgv_pip_deps_312_protobuf\",\"version\":\"3.12\"},{\"repo\":\"pgv_pip_deps_313_protobuf\",\"version\":\"3.13\"},{\"repo\":\"pgv_pip_deps_39_protobuf\",\"version\":\"3.9\"}]",
+                "six": "[{\"repo\":\"pgv_pip_deps_310_six\",\"version\":\"3.10\"},{\"repo\":\"pgv_pip_deps_311_six\",\"version\":\"3.11\"},{\"repo\":\"pgv_pip_deps_312_six\",\"version\":\"3.12\"},{\"repo\":\"pgv_pip_deps_313_six\",\"version\":\"3.13\"},{\"repo\":\"pgv_pip_deps_39_six\",\"version\":\"3.9\"}]",
+                "validate_email": "[{\"repo\":\"pgv_pip_deps_310_validate_email\",\"version\":\"3.10\"},{\"repo\":\"pgv_pip_deps_311_validate_email\",\"version\":\"3.11\"},{\"repo\":\"pgv_pip_deps_312_validate_email\",\"version\":\"3.12\"},{\"repo\":\"pgv_pip_deps_313_validate_email\",\"version\":\"3.13\"},{\"repo\":\"pgv_pip_deps_39_validate_email\",\"version\":\"3.9\"}]",
+                "wheel": "[{\"repo\":\"pgv_pip_deps_310_wheel\",\"version\":\"3.10\"},{\"repo\":\"pgv_pip_deps_311_wheel\",\"version\":\"3.11\"},{\"repo\":\"pgv_pip_deps_312_wheel\",\"version\":\"3.12\"},{\"repo\":\"pgv_pip_deps_313_wheel\",\"version\":\"3.13\"},{\"repo\":\"pgv_pip_deps_39_wheel\",\"version\":\"3.9\"}]"
+              },
+              "packages": [
+                "astunparse",
+                "jinja2",
+                "markupsafe",
+                "protobuf",
+                "six",
+                "validate_email",
+                "wheel"
+              ],
+              "groups": {}
+            }
+          },
+          "grpc_python_dependencies_310_proto_plus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_proto_plus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "proto-plus==1.22.3"
+            }
+          },
+          "grpc_python_dependencies_311_requests": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_requests",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_313_google_cloud_trace": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_google_cloud_trace",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "google-cloud-trace==1.11.3"
+            }
+          },
+          "grpc_python_dependencies_313_opentelemetry_api": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_opentelemetry_api",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "opentelemetry-api==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_310_chardet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_chardet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "rules_fuzzing_py_deps_39_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_39_absl_py",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "rules_fuzzing_py_deps_39",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "grpc_python_dependencies_312_proto_plus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_proto_plus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "proto-plus==1.22.3"
+            }
+          },
+          "grpc_python_dependencies_39_google_cloud_monitoring": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_google_cloud_monitoring",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "google-cloud-monitoring==2.16.0"
+            }
+          },
+          "grpc_python_dependencies_310_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_setuptools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "setuptools==44.1.1"
+            }
+          },
+          "grpc_python_dependencies_39_opentelemetry_semantic_conventions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_opentelemetry_semantic_conventions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "opentelemetry-semantic-conventions==0.46b0"
+            }
+          },
+          "grpc_python_dependencies_310_deprecated": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_deprecated",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "Deprecated==1.2.14"
+            }
+          },
+          "grpc_python_dependencies_310_rsa": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_rsa",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_39_zope_interface": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_zope_interface",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "zope.interface==6.1"
+            }
+          },
+          "pgv_pip_deps_312_jinja2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_312_jinja2",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pgv_pip_deps_312",
+              "requirement": "jinja2==3.1.3"
+            }
+          },
+          "grpc_python_dependencies_311_certifi": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_certifi",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "certifi==2023.7.22"
+            }
+          },
+          "grpc_python_dependencies_311_google_cloud_monitoring": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_google_cloud_monitoring",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "google-cloud-monitoring==2.16.0"
+            }
+          },
+          "grpc_python_dependencies_312_zope_event": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_zope_event",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "zope.event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_310_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_absl_py",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "absl-py==1.4.0"
+            }
+          },
+          "grpc_python_dependencies_311_greenlet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_greenlet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "pgv_pip_deps_310_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_310_wheel",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pgv_pip_deps_310",
+              "requirement": "wheel==0.43.0"
+            }
+          },
+          "grpc_python_dependencies_313_opentelemetry_sdk": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_opentelemetry_sdk",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "opentelemetry-sdk==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_313_prometheus_client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_prometheus_client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "prometheus_client==0.20.0"
+            }
+          },
+          "grpc_python_dependencies_311_google_auth": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_google_auth",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "google-auth==2.23.4"
+            }
+          },
+          "grpc_python_dependencies_310_pyasn1_modules": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_pyasn1_modules",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "rules_fuzzing_py_deps_312_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_312_six",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "rules_fuzzing_py_deps_312",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "grpc_python_dependencies_311_cython": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_cython",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "cython==3.0.0"
+            }
+          },
+          "rules_fuzzing_py_deps_311_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_311_absl_py",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_fuzzing_py_deps_311",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "grpc_python_dependencies_313_oauth2client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_oauth2client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_39_prometheus_client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_prometheus_client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "prometheus_client==0.20.0"
+            }
+          },
+          "grpc_python_dependencies_39_opentelemetry_sdk": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_opentelemetry_sdk",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "opentelemetry-sdk==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_313_google_auth": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_google_auth",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "google-auth==2.23.4"
+            }
+          },
+          "grpc_python_dependencies_311_zipp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_zipp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "zipp==3.17.0"
+            }
+          },
+          "rules_fuzzing_py_deps_39_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_39_six",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "rules_fuzzing_py_deps_39",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "grpc_python_dependencies_311_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_protobuf",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "protobuf>=5.27.1,<6.0dev"
+            }
+          },
+          "grpc_python_dependencies_311_typing_extensions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_typing_extensions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "typing-extensions==4.9.0"
+            }
+          },
+          "grpc_python_dependencies_312_opentelemetry_semantic_conventions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_opentelemetry_semantic_conventions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "opentelemetry-semantic-conventions==0.46b0"
+            }
+          },
+          "pgv_pip_deps_39_jinja2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_39_jinja2",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pgv_pip_deps_39",
+              "requirement": "jinja2==3.1.3"
+            }
+          },
+          "grpc_python_dependencies_310_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_protobuf",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "protobuf>=5.27.1,<6.0dev"
+            }
+          },
+          "grpc_python_dependencies_313_greenlet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_greenlet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "pgv_pip_deps_312_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_312_wheel",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pgv_pip_deps_312",
+              "requirement": "wheel==0.43.0"
+            }
+          },
+          "grpc_python_dependencies_311_proto_plus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_proto_plus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "proto-plus==1.22.3"
+            }
+          },
+          "grpc_python_dependencies_310_certifi": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_certifi",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "certifi==2023.7.22"
+            }
+          },
+          "pgv_pip_deps_313_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_313_protobuf",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "pgv_pip_deps_313",
+              "requirement": "protobuf==5.26.0"
+            }
+          },
+          "pip_deps_312_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_312_setuptools",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pip_deps_312",
+              "requirement": "setuptools<=70.3.0"
+            }
+          },
+          "grpc_python_dependencies_312_typing_extensions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_typing_extensions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "typing-extensions==4.9.0"
+            }
+          },
+          "grpc_python_dependencies_313_urllib3": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_urllib3",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "urllib3==1.26.18"
+            }
+          },
+          "grpc_python_dependencies_312_google_api_core": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_google_api_core",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "google-api-core==1.34.1"
+            }
+          },
+          "grpc_python_dependencies_311_opentelemetry_exporter_prometheus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_opentelemetry_exporter_prometheus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "opentelemetry-exporter-prometheus==0.46b0"
+            }
+          },
+          "pgv_pip_deps_39_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_39_protobuf",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pgv_pip_deps_39",
+              "requirement": "protobuf==5.26.0"
+            }
+          },
+          "grpc_python_dependencies_311_wrapt": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_wrapt",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "wrapt==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_312_pyasn1": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_pyasn1",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "pyasn1==0.5.0"
+            }
+          },
+          "grpc_python_dependencies_310_pyasn1": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_pyasn1",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "pyasn1==0.5.0"
+            }
+          },
+          "grpc_python_dependencies_310_urllib3": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_urllib3",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "urllib3==1.26.18"
+            }
+          },
+          "grpc_python_dependencies_312_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_googleapis_common_protos",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "googleapis-common-protos==1.63.1"
+            }
+          },
+          "pgv_pip_deps_39_markupsafe": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_39_markupsafe",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pgv_pip_deps_39",
+              "requirement": "markupsafe==2.1.5"
+            }
+          },
+          "grpc_python_dependencies_311_opentelemetry_semantic_conventions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_opentelemetry_semantic_conventions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "opentelemetry-semantic-conventions==0.46b0"
+            }
+          },
+          "pgv_pip_deps_312_markupsafe": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_312_markupsafe",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pgv_pip_deps_312",
+              "requirement": "markupsafe==2.1.5"
+            }
+          },
+          "grpc_python_dependencies_313_certifi": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_certifi",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "certifi==2023.7.22"
+            }
+          },
+          "grpc_python_dependencies_313_zope_interface": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_zope_interface",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "zope.interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_313_typing_extensions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_typing_extensions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "typing-extensions==4.9.0"
+            }
+          },
+          "grpc_python_dependencies_313_opentelemetry_exporter_prometheus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_opentelemetry_exporter_prometheus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "opentelemetry-exporter-prometheus==0.46b0"
+            }
+          },
+          "grpc_python_dependencies_312_chardet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_chardet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies",
+              "repo_name": "grpc_python_dependencies",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "[{\"repo\":\"grpc_python_dependencies_310_absl_py\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_absl_py\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_absl_py\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_absl_py\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_absl_py\",\"version\":\"3.9\"}]",
+                "cachetools": "[{\"repo\":\"grpc_python_dependencies_310_cachetools\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_cachetools\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_cachetools\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_cachetools\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_cachetools\",\"version\":\"3.9\"}]",
+                "certifi": "[{\"repo\":\"grpc_python_dependencies_310_certifi\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_certifi\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_certifi\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_certifi\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_certifi\",\"version\":\"3.9\"}]",
+                "chardet": "[{\"repo\":\"grpc_python_dependencies_310_chardet\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_chardet\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_chardet\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_chardet\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_chardet\",\"version\":\"3.9\"}]",
+                "charset_normalizer": "[{\"repo\":\"grpc_python_dependencies_310_charset_normalizer\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_charset_normalizer\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_charset_normalizer\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_charset_normalizer\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_charset_normalizer\",\"version\":\"3.9\"}]",
+                "coverage": "[{\"repo\":\"grpc_python_dependencies_310_coverage\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_coverage\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_coverage\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_coverage\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_coverage\",\"version\":\"3.9\"}]",
+                "cython": "[{\"repo\":\"grpc_python_dependencies_310_cython\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_cython\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_cython\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_cython\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_cython\",\"version\":\"3.9\"}]",
+                "deprecated": "[{\"repo\":\"grpc_python_dependencies_310_deprecated\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_deprecated\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_deprecated\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_deprecated\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_deprecated\",\"version\":\"3.9\"}]",
+                "gevent": "[{\"repo\":\"grpc_python_dependencies_310_gevent\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_gevent\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_gevent\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_gevent\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_gevent\",\"version\":\"3.9\"}]",
+                "google_api_core": "[{\"repo\":\"grpc_python_dependencies_310_google_api_core\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_google_api_core\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_google_api_core\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_google_api_core\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_google_api_core\",\"version\":\"3.9\"}]",
+                "google_auth": "[{\"repo\":\"grpc_python_dependencies_310_google_auth\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_google_auth\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_google_auth\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_google_auth\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_google_auth\",\"version\":\"3.9\"}]",
+                "google_cloud_monitoring": "[{\"repo\":\"grpc_python_dependencies_310_google_cloud_monitoring\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_google_cloud_monitoring\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_google_cloud_monitoring\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_google_cloud_monitoring\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_google_cloud_monitoring\",\"version\":\"3.9\"}]",
+                "google_cloud_trace": "[{\"repo\":\"grpc_python_dependencies_310_google_cloud_trace\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_google_cloud_trace\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_google_cloud_trace\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_google_cloud_trace\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_google_cloud_trace\",\"version\":\"3.9\"}]",
+                "googleapis_common_protos": "[{\"repo\":\"grpc_python_dependencies_310_googleapis_common_protos\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_googleapis_common_protos\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_googleapis_common_protos\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_googleapis_common_protos\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_googleapis_common_protos\",\"version\":\"3.9\"}]",
+                "greenlet": "[{\"repo\":\"grpc_python_dependencies_310_greenlet\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_greenlet\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_greenlet\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_greenlet\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_greenlet\",\"version\":\"3.9\"}]",
+                "idna": "[{\"repo\":\"grpc_python_dependencies_310_idna\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_idna\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_idna\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_idna\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_idna\",\"version\":\"3.9\"}]",
+                "importlib_metadata": "[{\"repo\":\"grpc_python_dependencies_310_importlib_metadata\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_importlib_metadata\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_importlib_metadata\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_importlib_metadata\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_importlib_metadata\",\"version\":\"3.9\"}]",
+                "oauth2client": "[{\"repo\":\"grpc_python_dependencies_310_oauth2client\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_oauth2client\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_oauth2client\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_oauth2client\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_oauth2client\",\"version\":\"3.9\"}]",
+                "opencensus_context": "[{\"repo\":\"grpc_python_dependencies_310_opencensus_context\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_opencensus_context\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_opencensus_context\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_opencensus_context\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_opencensus_context\",\"version\":\"3.9\"}]",
+                "opentelemetry_api": "[{\"repo\":\"grpc_python_dependencies_310_opentelemetry_api\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_opentelemetry_api\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_opentelemetry_api\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_opentelemetry_api\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_opentelemetry_api\",\"version\":\"3.9\"}]",
+                "opentelemetry_exporter_prometheus": "[{\"repo\":\"grpc_python_dependencies_310_opentelemetry_exporter_prometheus\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_opentelemetry_exporter_prometheus\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_opentelemetry_exporter_prometheus\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_opentelemetry_exporter_prometheus\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_opentelemetry_exporter_prometheus\",\"version\":\"3.9\"}]",
+                "opentelemetry_resourcedetector_gcp": "[{\"repo\":\"grpc_python_dependencies_310_opentelemetry_resourcedetector_gcp\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_opentelemetry_resourcedetector_gcp\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_opentelemetry_resourcedetector_gcp\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_opentelemetry_resourcedetector_gcp\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_opentelemetry_resourcedetector_gcp\",\"version\":\"3.9\"}]",
+                "opentelemetry_sdk": "[{\"repo\":\"grpc_python_dependencies_310_opentelemetry_sdk\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_opentelemetry_sdk\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_opentelemetry_sdk\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_opentelemetry_sdk\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_opentelemetry_sdk\",\"version\":\"3.9\"}]",
+                "opentelemetry_semantic_conventions": "[{\"repo\":\"grpc_python_dependencies_310_opentelemetry_semantic_conventions\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_opentelemetry_semantic_conventions\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_opentelemetry_semantic_conventions\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_opentelemetry_semantic_conventions\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_opentelemetry_semantic_conventions\",\"version\":\"3.9\"}]",
+                "prometheus_client": "[{\"repo\":\"grpc_python_dependencies_310_prometheus_client\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_prometheus_client\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_prometheus_client\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_prometheus_client\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_prometheus_client\",\"version\":\"3.9\"}]",
+                "proto_plus": "[{\"repo\":\"grpc_python_dependencies_310_proto_plus\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_proto_plus\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_proto_plus\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_proto_plus\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_proto_plus\",\"version\":\"3.9\"}]",
+                "protobuf": "[{\"repo\":\"grpc_python_dependencies_310_protobuf\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_protobuf\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_protobuf\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_protobuf\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_protobuf\",\"version\":\"3.9\"}]",
+                "pyasn1": "[{\"repo\":\"grpc_python_dependencies_310_pyasn1\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_pyasn1\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_pyasn1\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_pyasn1\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_pyasn1\",\"version\":\"3.9\"}]",
+                "pyasn1_modules": "[{\"repo\":\"grpc_python_dependencies_310_pyasn1_modules\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_pyasn1_modules\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_pyasn1_modules\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_pyasn1_modules\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_pyasn1_modules\",\"version\":\"3.9\"}]",
+                "requests": "[{\"repo\":\"grpc_python_dependencies_310_requests\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_requests\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_requests\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_requests\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_requests\",\"version\":\"3.9\"}]",
+                "rsa": "[{\"repo\":\"grpc_python_dependencies_310_rsa\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_rsa\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_rsa\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_rsa\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_rsa\",\"version\":\"3.9\"}]",
+                "setuptools": "[{\"repo\":\"grpc_python_dependencies_310_setuptools\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_setuptools\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_setuptools\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_setuptools\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_setuptools\",\"version\":\"3.9\"}]",
+                "typing_extensions": "[{\"repo\":\"grpc_python_dependencies_310_typing_extensions\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_typing_extensions\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_typing_extensions\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_typing_extensions\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_typing_extensions\",\"version\":\"3.9\"}]",
+                "urllib3": "[{\"repo\":\"grpc_python_dependencies_310_urllib3\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_urllib3\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_urllib3\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_urllib3\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_urllib3\",\"version\":\"3.9\"}]",
+                "wheel": "[{\"repo\":\"grpc_python_dependencies_310_wheel\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_wheel\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_wheel\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_wheel\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_wheel\",\"version\":\"3.9\"}]",
+                "wrapt": "[{\"repo\":\"grpc_python_dependencies_310_wrapt\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_wrapt\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_wrapt\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_wrapt\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_wrapt\",\"version\":\"3.9\"}]",
+                "zipp": "[{\"repo\":\"grpc_python_dependencies_310_zipp\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_zipp\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_zipp\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_zipp\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_zipp\",\"version\":\"3.9\"}]",
+                "zope_event": "[{\"repo\":\"grpc_python_dependencies_310_zope_event\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_zope_event\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_zope_event\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_zope_event\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_zope_event\",\"version\":\"3.9\"}]",
+                "zope_interface": "[{\"repo\":\"grpc_python_dependencies_310_zope_interface\",\"version\":\"3.10\"},{\"repo\":\"grpc_python_dependencies_311_zope_interface\",\"version\":\"3.11\"},{\"repo\":\"grpc_python_dependencies_312_zope_interface\",\"version\":\"3.12\"},{\"repo\":\"grpc_python_dependencies_313_zope_interface\",\"version\":\"3.13\"},{\"repo\":\"grpc_python_dependencies_39_zope_interface\",\"version\":\"3.9\"}]"
+              },
+              "packages": [
+                "absl_py",
+                "cachetools",
+                "certifi",
+                "chardet",
+                "charset_normalizer",
+                "coverage",
+                "cython",
+                "deprecated",
+                "gevent",
+                "google_api_core",
+                "google_auth",
+                "google_cloud_monitoring",
+                "google_cloud_trace",
+                "googleapis_common_protos",
+                "greenlet",
+                "idna",
+                "importlib_metadata",
+                "oauth2client",
+                "opencensus_context",
+                "opentelemetry_api",
+                "opentelemetry_exporter_prometheus",
+                "opentelemetry_resourcedetector_gcp",
+                "opentelemetry_sdk",
+                "opentelemetry_semantic_conventions",
+                "prometheus_client",
+                "proto_plus",
+                "protobuf",
+                "pyasn1",
+                "pyasn1_modules",
+                "requests",
+                "rsa",
+                "setuptools",
+                "typing_extensions",
+                "urllib3",
+                "wheel",
+                "wrapt",
+                "zipp",
+                "zope_event",
+                "zope_interface"
+              ],
+              "groups": {}
+            }
+          },
+          "pgv_pip_deps_311_markupsafe": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_311_markupsafe",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pgv_pip_deps_311",
+              "requirement": "markupsafe==2.1.5"
+            }
+          },
+          "grpc_python_dependencies_311_deprecated": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_deprecated",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "Deprecated==1.2.14"
+            }
+          },
+          "grpc_python_dependencies_39_requests": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_requests",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_310_cachetools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_cachetools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "cachetools==5.3.2"
+            }
+          },
+          "grpc_python_dependencies_312_coverage": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_coverage",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_310_google_cloud_trace": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_google_cloud_trace",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "google-cloud-trace==1.11.3"
+            }
+          },
+          "grpc_python_dependencies_39_oauth2client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_oauth2client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "pgv_pip_deps_311_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_311_six",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pgv_pip_deps_311",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_39_idna": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_idna",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "idna==2.7"
+            }
+          },
+          "pgv_pip_deps_311_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_311_protobuf",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pgv_pip_deps_311",
+              "requirement": "protobuf==5.26.0"
+            }
+          },
+          "pip_deps_38_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_38_setuptools",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_8_host//:python",
+              "repo": "pip_deps_38",
+              "requirement": "setuptools<=70.3.0"
+            }
+          },
+          "grpc_python_dependencies_310_opentelemetry_semantic_conventions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_opentelemetry_semantic_conventions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "opentelemetry-semantic-conventions==0.46b0"
+            }
+          },
+          "grpc_python_dependencies_312_importlib_metadata": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_importlib_metadata",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "importlib-metadata==6.11.0"
+            }
+          },
+          "grpc_python_dependencies_39_zope_event": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_zope_event",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "zope.event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_310_importlib_metadata": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_importlib_metadata",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "importlib-metadata==6.11.0"
+            }
+          },
+          "grpc_python_dependencies_310_zipp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_zipp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "zipp==3.17.0"
+            }
+          },
+          "pip_deps_39_numpy": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_39_numpy",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pip_deps_39",
+              "requirement": "numpy<=1.26.1"
+            }
+          },
+          "grpc_python_dependencies_312_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_absl_py",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "absl-py==1.4.0"
+            }
+          },
+          "pgv_pip_deps_39_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_39_six",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pgv_pip_deps_39",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "pgv_pip_deps_310_jinja2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_310_jinja2",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pgv_pip_deps_310",
+              "requirement": "jinja2==3.1.3"
+            }
+          },
+          "pgv_pip_deps_311_validate_email": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_311_validate_email",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pgv_pip_deps_311",
+              "requirement": "validate-email==1.3"
+            }
+          },
+          "grpc_python_dependencies_312_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_protobuf",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "protobuf>=5.27.1,<6.0dev"
+            }
+          },
+          "grpc_python_dependencies_313_rsa": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_rsa",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_39_cython": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_cython",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "cython==3.0.0"
+            }
+          },
+          "pgv_pip_deps_313_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_313_wheel",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "pgv_pip_deps_313",
+              "requirement": "wheel==0.43.0"
+            }
+          },
+          "grpc_python_dependencies_310_typing_extensions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_typing_extensions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "typing-extensions==4.9.0"
+            }
+          },
+          "pip_deps_38_numpy": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_38_numpy",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_8_host//:python",
+              "repo": "pip_deps_38",
+              "requirement": "numpy<=1.26.1"
+            }
+          },
+          "grpc_python_dependencies_313_opentelemetry_semantic_conventions": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_opentelemetry_semantic_conventions",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "opentelemetry-semantic-conventions==0.46b0"
+            }
+          },
+          "pgv_pip_deps_310_astunparse": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_310_astunparse",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pgv_pip_deps_310",
+              "requirement": "astunparse==1.6.3"
+            }
+          },
+          "rules_fuzzing_py_deps_38_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_38_six",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_8_host//:python",
+              "repo": "rules_fuzzing_py_deps_38",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "grpc_python_dependencies_310_opentelemetry_api": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_opentelemetry_api",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "opentelemetry-api==1.25.0"
+            }
+          },
+          "pgv_pip_deps_313_validate_email": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_313_validate_email",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "pgv_pip_deps_313",
+              "requirement": "validate-email==1.3"
+            }
+          },
+          "rules_fuzzing_py_deps_311_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_311_six",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_fuzzing_py_deps_311",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "grpc_python_dependencies_39_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_googleapis_common_protos",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "googleapis-common-protos==1.63.1"
+            }
+          },
+          "pip_deps_310_numpy": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_310_numpy",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pip_deps_310",
+              "requirement": "numpy<=1.26.1"
+            }
+          },
+          "grpc_python_dependencies_311_charset_normalizer": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_charset_normalizer",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "grpc_python_dependencies_39_coverage": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_coverage",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_313_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_protobuf",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "protobuf>=5.27.1,<6.0dev"
+            }
+          },
+          "grpc_python_dependencies_310_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_wheel",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "wheel==0.38.1"
+            }
+          },
+          "grpc_python_dependencies_313_zipp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_zipp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "zipp==3.17.0"
+            }
+          },
+          "grpc_python_dependencies_39_opentelemetry_exporter_prometheus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_opentelemetry_exporter_prometheus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "opentelemetry-exporter-prometheus==0.46b0"
+            }
+          },
+          "pgv_pip_deps_310_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_310_protobuf",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pgv_pip_deps_310",
+              "requirement": "protobuf==5.26.0"
+            }
+          },
+          "pgv_pip_deps_313_markupsafe": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_313_markupsafe",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "pgv_pip_deps_313",
+              "requirement": "markupsafe==2.1.5"
+            }
+          },
+          "grpc_python_dependencies_310_opencensus_context": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_opencensus_context",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "opencensus-context==0.1.3"
+            }
+          },
+          "grpc_python_dependencies_311_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_absl_py",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "absl-py==1.4.0"
+            }
+          },
+          "grpc_python_dependencies_311_opentelemetry_api": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_opentelemetry_api",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "opentelemetry-api==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_312_certifi": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_certifi",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "certifi==2023.7.22"
+            }
+          },
+          "pgv_pip_deps_39_validate_email": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_39_validate_email",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "pgv_pip_deps_39",
+              "requirement": "validate-email==1.3"
+            }
+          },
+          "grpc_python_dependencies_39_importlib_metadata": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_importlib_metadata",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "importlib-metadata==6.11.0"
+            }
+          },
+          "grpc_python_dependencies_311_pyasn1_modules": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_pyasn1_modules",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_313_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_wheel",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "wheel==0.38.1"
+            }
+          },
+          "grpc_python_dependencies_311_cachetools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_cachetools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "cachetools==5.3.2"
+            }
+          },
+          "grpc_python_dependencies_312_requests": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_requests",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_312_google_cloud_monitoring": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_google_cloud_monitoring",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "google-cloud-monitoring==2.16.0"
+            }
+          },
+          "grpc_python_dependencies_39_greenlet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_greenlet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "grpc_python_dependencies_310_gevent": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_gevent",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "gevent==22.08.0"
+            }
+          },
+          "grpc_python_dependencies_39_google_api_core": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_google_api_core",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "google-api-core==1.34.1"
+            }
+          },
+          "grpc_python_dependencies_312_wrapt": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_wrapt",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "wrapt==1.16.0"
+            }
+          },
+          "pip_deps_310_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_310_setuptools",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "pip_deps_310",
+              "requirement": "setuptools<=70.3.0"
+            }
+          },
+          "grpc_python_dependencies_310_cython": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_cython",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "cython==3.0.0"
+            }
+          },
+          "grpc_python_dependencies_312_cython": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_cython",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "cython==3.0.0"
+            }
+          },
+          "grpc_python_dependencies_311_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_setuptools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "setuptools==44.1.1"
+            }
+          },
+          "grpc_python_dependencies_310_google_api_core": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_google_api_core",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "google-api-core==1.34.1"
+            }
+          },
+          "grpc_python_dependencies_313_google_api_core": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_google_api_core",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "google-api-core==1.34.1"
+            }
+          },
+          "grpc_python_dependencies_39_wrapt": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_wrapt",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "wrapt==1.16.0"
+            }
+          },
+          "pgv_pip_deps_313_astunparse": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_313_astunparse",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "pgv_pip_deps_313",
+              "requirement": "astunparse==1.6.3"
+            }
+          },
+          "grpc_python_dependencies_39_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_absl_py",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "absl-py==1.4.0"
+            }
+          },
+          "grpc_python_dependencies_313_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_googleapis_common_protos",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "googleapis-common-protos==1.63.1"
+            }
+          },
+          "rules_fuzzing_py_deps_310_absl_py": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_310_absl_py",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "rules_fuzzing_py_deps_310",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "grpc_python_dependencies_311_zope_interface": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_zope_interface",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "zope.interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_310_charset_normalizer": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_charset_normalizer",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "grpc_python_dependencies_39_rsa": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_rsa",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_312_pyasn1_modules": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_pyasn1_modules",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_312_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_wheel",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "wheel==0.38.1"
+            }
+          },
+          "pip_deps_312_numpy": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pip_deps_312_numpy",
+              "dep_template": "@pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pip_deps_312",
+              "requirement": "numpy<=1.26.1"
+            }
+          },
+          "grpc_python_dependencies_311_prometheus_client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_prometheus_client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "prometheus_client==0.20.0"
+            }
+          },
+          "grpc_python_dependencies_312_rsa": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_rsa",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_39_setuptools": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_setuptools",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "setuptools==44.1.1"
+            }
+          },
+          "rules_fuzzing_py_deps_310_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~rules_fuzzing_py_deps_310_six",
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "rules_fuzzing_py_deps_310",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "pgv_pip_deps_311_jinja2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_311_jinja2",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "pgv_pip_deps_311",
+              "requirement": "jinja2==3.1.3"
+            }
+          },
+          "pgv_pip_deps_312_six": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_312_six",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pgv_pip_deps_312",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_313_opencensus_context": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_opencensus_context",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "opencensus-context==0.1.3"
+            }
+          },
+          "grpc_python_dependencies_310_coverage": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_coverage",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_313_zope_event": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_zope_event",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "zope.event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_312_opencensus_context": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_opencensus_context",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "opencensus-context==0.1.3"
+            }
+          },
+          "grpc_python_dependencies_311_opencensus_context": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_opencensus_context",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "opencensus-context==0.1.3"
+            }
+          },
+          "grpc_python_dependencies_313_gevent": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_gevent",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "gevent==22.08.0"
+            }
+          },
+          "grpc_python_dependencies_310_wrapt": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_wrapt",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "wrapt==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_312_google_auth": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_google_auth",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "google-auth==2.23.4"
+            }
+          },
+          "pgv_pip_deps_312_validate_email": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~pgv_pip_deps_312_validate_email",
+              "dep_template": "@pgv_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "pgv_pip_deps_312",
+              "requirement": "validate-email==1.3"
+            }
+          },
+          "grpc_python_dependencies_311_wheel": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_wheel",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "wheel==0.38.1"
+            }
+          },
+          "grpc_python_dependencies_313_proto_plus": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_proto_plus",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "proto-plus==1.22.3"
+            }
+          },
+          "grpc_python_dependencies_312_idna": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_idna",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_310_google_auth": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_310_google_auth",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "google-auth==2.23.4"
+            }
+          },
+          "grpc_python_dependencies_39_gevent": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_gevent",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "gevent==22.08.0"
+            }
+          },
+          "grpc_python_dependencies_311_oauth2client": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_oauth2client",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_313_charset_normalizer": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_313_charset_normalizer",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_13_host//:python",
+              "repo": "grpc_python_dependencies_313",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "grpc_python_dependencies_311_chardet": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_chardet",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_39_opentelemetry_resourcedetector_gcp": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_opentelemetry_resourcedetector_gcp",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "opentelemetry-resourcedetector-gcp==1.6.0a0"
+            }
+          },
+          "grpc_python_dependencies_311_opentelemetry_sdk": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_311_opentelemetry_sdk",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "opentelemetry-sdk==1.25.0"
+            }
+          },
+          "grpc_python_dependencies_312_charset_normalizer": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_312_charset_normalizer",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "grpc_python_dependencies_39_protobuf": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip~grpc_python_dependencies_39_protobuf",
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "protobuf>=5.27.1,<6.0dev"
+            }
+          }
+        }
+      }
+    },
     "@@rules_python~0.40.0//python/extensions:python.bzl%python": {
       "general": {
         "bzlTransitiveDigest": "4xgskvvy896DwjJ/70fEPWMfmOrkSDynM1I5ltwey3s=",
@@ -12624,6 +16929,2551 @@
         }
       }
     },
+    "@@rules_python~0.40.0//python/private/pypi:pip.bzl%pip_internal": {
+      "general": {
+        "bzlTransitiveDigest": "srvVFqc3vDEZJWyzD05oPJ0vILJHPdsZHd5U3TWggL4=",
+        "accumulatedFileDigests": {
+          "@@rules_python~0.40.0//tools/publish:requirements_darwin.txt": "2994136eab7e57b083c3de76faf46f70fad130bc8e7360a7fed2b288b69e79dc",
+          "@@rules_python~0.40.0//tools/publish:requirements_linux.txt": "8175b4c8df50ae2f22d1706961884beeb54e7da27bd2447018314a175981997d",
+          "@@rules_python~0.40.0//tools/publish:requirements_windows.txt": "7673adc71dc1a81d3661b90924d7a7c0fc998cd508b3cb4174337cef3f2de556"
+        },
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_sdist_1c39c601": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cffi_sdist_1c39c601",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "cffi-1.17.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "urllib3-2.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_sdist_e7d814a8": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_urllib3_sdist_e7d814a8",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "urllib3-2.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16",
+              "urls": [
+                "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "0411beb0589eacb6734f28d5497ca2ed379eafab8ad8c84b31bb5c34072b7164",
+              "urls": [
+                "https://files.pythonhosted.org/packages/05/2b/85977d9e11713b5747595ee61f381bc820749daf83f07b90b6c9964cf932/nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_sdist_223217c3": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_sdist_223217c3",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "charset_normalizer-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_sdist_315b9001": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cryptography_sdist_315b9001",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "cryptography-43.0.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "5f36b271dae35c465ef5e9090e1fdaba4a60a56f0bb0ba03e0932a66f28b9189",
+              "urls": [
+                "https://files.pythonhosted.org/packages/72/f2/5c894d5265ab80a97c68ca36f25c8f6f0308abac649aaf152b74e7e854a8/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_sdist_2403533e": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_secretstorage_sdist_2403533e",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "SecretStorage-3.3.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+              "urls": [
+                "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco_functools-4.1.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "pycparser-2.22-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_sdist_12f65c9b": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_idna_sdist_12f65c9b",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "idna-3.10.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "19aaba96e0f795bd0a6c56291495ff59364f4300d4a39b29a0abc9cb3774a84b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c2/a8/3bb02d0c60a03ad3a112b76c46971e9480efa98a8946677b5a59f60130ca/nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pywin32-ctypes-0.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "readme_renderer-44.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_sdist_786ff802": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pygments_sdist_786ff802",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pygments-2.18.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
+              "urls": [
+                "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "14c5a72e9fe82aea5fe3072116ad4661af5cf8e8ff8fc5ad3450f123e4925e86",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/89/1daff5d9ba5a95a157c092c7c5f39b8dd2b1ddb4559966f808d31cfb67e0/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_py3_none_any_a817ac80": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_zipp_py3_none_any_a817ac80",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "zipp-3.20.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.20.2",
+              "sha256": "a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "backports_tarfile-1.2.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
+              "urls": [
+                "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "jeepney-0.8.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "SecretStorage-3.3.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
+              "urls": [
+                "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco.classes-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/33/b3682992ab2e9476b9c81fff22f02c8b0a1e6e1d49ee1750a67d85fd7ed2/cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "7b7c2a3c9eb1a827d42539aa64091640bd275b81e097cd1d8d82ef91ffa2e811",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2c/b6/42fc3c69cabf86b6b81e4c051a9b6e249c5ba9f8155590222c2622961f58/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "requests-toolbelt-1.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_py3_none_any_9836f509": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_rich_py3_none_any_9836f509",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rich-13.9.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.3",
+              "sha256": "9836f5096eb2172c9e77df411c1b009bace4193d6a481d534fea75ebba758283",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9a/e2/10e9819cf4a20bd8ea2f5dabafc2e6bf4a78d6a0965daeb60a4b34d1c11f/rich-13.9.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_twine_py3_none_any_215dbe7b": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_twine_py3_none_any_215dbe7b",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "twine-5.1.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_sdist_3a6b1873": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_docutils_sdist_3a6b1873",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "docutils-0.21.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_sdist_b07ebc55": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_keyring_sdist_b07ebc55",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "keyring-25.4.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a5/1c/2bdbcfd5d59dc6274ffb175bc29aa07ecbfab196830e0cfbde7bd861a2ea/keyring-25.4.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "markdown_it_py-3.0.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_py3_none_any_922820b5": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_certifi_py3_none_any_922820b5",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "certifi-2024.8.30-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_sdist_5482bfef": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_more_itertools_sdist_5482bfef",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "more-itertools-10.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_sdist_bec941d2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_certifi_sdist_bec941d2",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "certifi-2024.8.30.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_mdurl_py3_none_any_84008a41",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_sdist_bb413d29": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_mdurl_sdist_bb413d29",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "mdurl-0.1.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_py3_none_any_5426f817": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_keyring_py3_none_any_5426f817",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "keyring-25.4.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf",
+              "urls": [
+                "https://files.pythonhosted.org/packages/83/25/e6d59e5f0a0508d0dca8bb98c7f7fd3772fc943ac3f53d5ab18a218d32c0/keyring-25.4.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "42c64511469005058cd17cc1537578eac40ae9f7200bedcfd1fc1a05f4f8c200",
+              "urls": [
+                "https://files.pythonhosted.org/packages/45/b9/833f385403abaf0023c6547389ec7a7acf141ddd9d1f21573723a6eab39a/nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_sdist_97aacf9d": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_rfc3986_sdist_97aacf9d",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "rfc3986-2.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_twine_sdist_9aa08251": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_twine_sdist_9aa08251",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "twine-5.1.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_sdist_5df73835": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pkginfo_sdist_5df73835",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pkginfo-1.10.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/72/347ec5be4adc85c182ed2823d8d1c7b51e13b9a6b0c1aae59582eca652df/pkginfo-1.10.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "backports.tarfile-1.2.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "markdown-it-py-3.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
+              "urls": [
+                "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "f0eca9ca8628dbb4e916ae2491d72957fdd35f7a5d326b7032a345f111ac07fe",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a3/da/0c4e282bc3cff4a0adf37005fa1fb42257673fbc1bbf7d1ff639ec3d255a/nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pkginfo-1.10.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
+              "urls": [
+                "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_py3_none_any_946d195a": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_idna_py3_none_any_946d195a",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "idna-3.10-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_sdist_94a16692": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_sdist_94a16692",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "nh3-0.2.18.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "94a166927e53972a9698af9542ace4e38b9de50c34352b962f4d9a7d4c927af4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/73/10df50b42ddb547a907deeb2f3c9823022580a7a47281e8eae8e003a9639/nh3-0.2.18.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_sdist_55365417": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_requests_sdist_55365417",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "requests-2.32.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+              "urls": [
+                "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_sdist_491c8be9": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pycparser_sdist_491c8be9",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pycparser-2.22.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "de3ceed6e661954871d6cd78b410213bdcb136f79aafe22aa7182e028b8c7307",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1b/63/6ab90d0e5225ab9780f6c9fb52254fa36b52bb7c188df9201d05b647e5e1/nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pygments-2.18.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_sdist_71522656": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_importlib_metadata_sdist_71522656",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "importlib_metadata-8.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "3a157ab149e591bb638a55c8c6bcb8cdb559c8b12c13a8affaba6cedfe51713a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/81/c291231463d21da5f8bba82c8167a6d6893cc5419b0639801ee5d3aeb8a9/nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.context-6.0.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "more_itertools-10.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef",
+              "urls": [
+                "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "34c03fa78e328c691f982b7c03d4423bdfd7da69cd707fe572f544cf74ac23ad",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/a7/375afcc710dbe2d64cfbd69e31f82f3e423d43737258af01f6a56d844085/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_sdist_bc1e01b8": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_rich_sdist_bc1e01b8",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "rich-13.9.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.3",
+              "sha256": "bc1e01b899537598cf02579d2b9f4a415104d3fc439313a7a2c165d76557a08e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d9/e9/cf9ef5245d835065e6673781dbd4b8911d352fb770d56cf0879cf11b7ee1/rich-13.9.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests_toolbelt-1.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
+              "urls": [
+                "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32_ctypes-0.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "36c95d4b70530b320b365659bb5034341316e6a9b30f0b25fa9c9eff4c27a204",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/61/73a007c74c37895fdf66e0edcd881f5eaa17a348ff02f4bb4bc906d61085/nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_sdist_5efe48d2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jeepney_sdist_5efe48d2",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jeepney-0.8.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ac/25/e715fa0bc24ac2114ed69da33adf451a38abb6f3f24ec207908112e9ba53/cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rfc3986-2.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_sdist_bc9eb26f": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_zipp_sdist_bc9eb26f",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "zipp-3.20.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.20.2",
+              "sha256": "bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29",
+              "urls": [
+                "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps",
+              "repo_name": "rules_python_publish_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "backports_tarfile": "[{\"filename\":\"backports.tarfile-1.2.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7\",\"version\":\"3.11\"},{\"filename\":\"backports_tarfile-1.2.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2\",\"version\":\"3.11\"}]",
+                "certifi": "[{\"filename\":\"certifi-2024.8.30-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_certifi_py3_none_any_922820b5\",\"version\":\"3.11\"},{\"filename\":\"certifi-2024.8.30.tar.gz\",\"repo\":\"rules_python_publish_deps_311_certifi_sdist_bec941d2\",\"version\":\"3.11\"}]",
+                "cffi": "[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2\",\"version\":\"3.11\"},{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316\",\"version\":\"3.11\"},{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c\",\"version\":\"3.11\"},{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7\",\"version\":\"3.11\"},{\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49\",\"version\":\"3.11\"},{\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783\",\"version\":\"3.11\"},{\"filename\":\"cffi-1.17.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cffi_sdist_1c39c601\",\"version\":\"3.11\"}]",
+                "charset_normalizer": "[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe\",\"version\":\"3.11\"},{\"filename\":\"charset_normalizer-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_charset_normalizer_sdist_223217c3\",\"version\":\"3.11\"}]",
+                "cryptography": "[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004\",\"version\":\"3.11\"},{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72\",\"version\":\"3.11\"},{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1\",\"version\":\"3.11\"},{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39\",\"version\":\"3.11\"},{\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655\",\"version\":\"3.11\"},{\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d\",\"version\":\"3.11\"},{\"filename\":\"cryptography-43.0.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_cryptography_sdist_315b9001\",\"version\":\"3.11\"}]",
+                "docutils": "[{\"filename\":\"docutils-0.21.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9\",\"version\":\"3.11\"},{\"filename\":\"docutils-0.21.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_docutils_sdist_3a6b1873\",\"version\":\"3.11\"}]",
+                "idna": "[{\"filename\":\"idna-3.10-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_idna_py3_none_any_946d195a\",\"version\":\"3.11\"},{\"filename\":\"idna-3.10.tar.gz\",\"repo\":\"rules_python_publish_deps_311_idna_sdist_12f65c9b\",\"version\":\"3.11\"}]",
+                "importlib_metadata": "[{\"filename\":\"importlib_metadata-8.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197\",\"version\":\"3.11\"},{\"filename\":\"importlib_metadata-8.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_importlib_metadata_sdist_71522656\",\"version\":\"3.11\"}]",
+                "jaraco_classes": "[{\"filename\":\"jaraco.classes-3.4.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b\",\"version\":\"3.11\"},{\"filename\":\"jaraco.classes-3.4.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5\",\"version\":\"3.11\"}]",
+                "jaraco_context": "[{\"filename\":\"jaraco.context-6.0.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48\",\"version\":\"3.11\"},{\"filename\":\"jaraco_context-6.0.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5\",\"version\":\"3.11\"}]",
+                "jaraco_functools": "[{\"filename\":\"jaraco.functools-4.1.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13\",\"version\":\"3.11\"},{\"filename\":\"jaraco_functools-4.1.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2\",\"version\":\"3.11\"}]",
+                "jeepney": "[{\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad\",\"version\":\"3.11\"},{\"filename\":\"jeepney-0.8.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_jeepney_sdist_5efe48d2\",\"version\":\"3.11\"}]",
+                "keyring": "[{\"filename\":\"keyring-25.4.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_keyring_py3_none_any_5426f817\",\"version\":\"3.11\"},{\"filename\":\"keyring-25.4.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_keyring_sdist_b07ebc55\",\"version\":\"3.11\"}]",
+                "markdown_it_py": "[{\"filename\":\"markdown-it-py-3.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94\",\"version\":\"3.11\"},{\"filename\":\"markdown_it_py-3.0.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684\",\"version\":\"3.11\"}]",
+                "mdurl": "[{\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_mdurl_py3_none_any_84008a41\",\"version\":\"3.11\"},{\"filename\":\"mdurl-0.1.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_mdurl_sdist_bb413d29\",\"version\":\"3.11\"}]",
+                "more_itertools": "[{\"filename\":\"more-itertools-10.5.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_more_itertools_sdist_5482bfef\",\"version\":\"3.11\"},{\"filename\":\"more_itertools-10.5.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32\",\"version\":\"3.11\"}]",
+                "nh3": "[{\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18-cp37-abi3-win_amd64.whl\",\"repo\":\"rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819\",\"version\":\"3.11\"},{\"filename\":\"nh3-0.2.18.tar.gz\",\"repo\":\"rules_python_publish_deps_311_nh3_sdist_94a16692\",\"version\":\"3.11\"}]",
+                "pkginfo": "[{\"filename\":\"pkginfo-1.10.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2\",\"version\":\"3.11\"},{\"filename\":\"pkginfo-1.10.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pkginfo_sdist_5df73835\",\"version\":\"3.11\"}]",
+                "pycparser": "[{\"filename\":\"pycparser-2.22-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d\",\"version\":\"3.11\"},{\"filename\":\"pycparser-2.22.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pycparser_sdist_491c8be9\",\"version\":\"3.11\"}]",
+                "pygments": "[{\"filename\":\"pygments-2.18.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0\",\"version\":\"3.11\"},{\"filename\":\"pygments-2.18.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pygments_sdist_786ff802\",\"version\":\"3.11\"}]",
+                "pywin32_ctypes": "[{\"filename\":\"pywin32-ctypes-0.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04\",\"version\":\"3.11\"},{\"filename\":\"pywin32_ctypes-0.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337\",\"version\":\"3.11\"}]",
+                "readme_renderer": "[{\"filename\":\"readme_renderer-44.0-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b\",\"version\":\"3.11\"},{\"filename\":\"readme_renderer-44.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_readme_renderer_sdist_8712034e\",\"version\":\"3.11\"}]",
+                "requests": "[{\"filename\":\"requests-2.32.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_py3_none_any_70761cfe\",\"version\":\"3.11\"},{\"filename\":\"requests-2.32.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_sdist_55365417\",\"version\":\"3.11\"}]",
+                "requests_toolbelt": "[{\"filename\":\"requests-toolbelt-1.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3\",\"version\":\"3.11\"},{\"filename\":\"requests_toolbelt-1.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66\",\"version\":\"3.11\"}]",
+                "rfc3986": "[{\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b\",\"version\":\"3.11\"},{\"filename\":\"rfc3986-2.0.0.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rfc3986_sdist_97aacf9d\",\"version\":\"3.11\"}]",
+                "rich": "[{\"filename\":\"rich-13.9.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_rich_py3_none_any_9836f509\",\"version\":\"3.11\"},{\"filename\":\"rich-13.9.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_rich_sdist_bc1e01b8\",\"version\":\"3.11\"}]",
+                "secretstorage": "[{\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662\",\"version\":\"3.11\"},{\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_secretstorage_sdist_2403533e\",\"version\":\"3.11\"}]",
+                "twine": "[{\"filename\":\"twine-5.1.1-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_twine_py3_none_any_215dbe7b\",\"version\":\"3.11\"},{\"filename\":\"twine-5.1.1.tar.gz\",\"repo\":\"rules_python_publish_deps_311_twine_sdist_9aa08251\",\"version\":\"3.11\"}]",
+                "urllib3": "[{\"filename\":\"urllib3-2.2.3-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0\",\"version\":\"3.11\"},{\"filename\":\"urllib3-2.2.3.tar.gz\",\"repo\":\"rules_python_publish_deps_311_urllib3_sdist_e7d814a8\",\"version\":\"3.11\"}]",
+                "zipp": "[{\"filename\":\"zipp-3.20.2-py3-none-any.whl\",\"repo\":\"rules_python_publish_deps_311_zipp_py3_none_any_a817ac80\",\"version\":\"3.11\"},{\"filename\":\"zipp-3.20.2.tar.gz\",\"repo\":\"rules_python_publish_deps_311_zipp_sdist_bc9eb26f\",\"version\":\"3.11\"}]"
+              },
+              "packages": [
+                "backports_tarfile",
+                "certifi",
+                "charset_normalizer",
+                "docutils",
+                "idna",
+                "importlib_metadata",
+                "jaraco_classes",
+                "jaraco_context",
+                "jaraco_functools",
+                "keyring",
+                "markdown_it_py",
+                "mdurl",
+                "more_itertools",
+                "nh3",
+                "pkginfo",
+                "pygments",
+                "readme_renderer",
+                "requests",
+                "requests_toolbelt",
+                "rfc3986",
+                "rich",
+                "twine",
+                "urllib3",
+                "zipp"
+              ],
+              "groups": {}
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.classes-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco_context-6.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_py3_none_any_70761cfe": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_requests_py3_none_any_70761cfe",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-2.32.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_sdist_8712034e": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_readme_renderer_sdist_8712034e",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "readme_renderer-44.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13": {
+            "bzlFile": "@@rules_python~0.40.0//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "name": "rules_python~0.40.0~pip_internal~rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13",
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.functools-4.1.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~0.40.0~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl"
+              ]
+            }
+          }
+        }
+      }
+    },
     "@@rules_shell~0.3.0//shell/private/extensions:sh_configure.bzl%sh_configure": {
       "general": {
         "bzlTransitiveDigest": "GiQdaEdSaKIKKFfskWOKLq3N1O5Xg3JMTvUnNjF3b0E=",
@@ -12635,6 +19485,165 @@
             "ruleClassName": "sh_config",
             "attributes": {
               "name": "rules_shell~0.3.0~sh_configure~local_config_shell"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_swift~1.18.0//swift:extensions.bzl%non_module_deps": {
+      "general": {
+        "bzlTransitiveDigest": "NeY+A0kxtTRPGfTzuLz8MPed8SDQ4RRV8nws6iOmgRs=",
+        "accumulatedFileDigests": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_grpc_grpc_swift": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_grpc_grpc_swift",
+              "urls": [
+                "https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"
+              ],
+              "sha256": "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+              "strip_prefix": "grpc-swift-1.16.0/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_grpc_grpc_swift/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_extras": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_nio_extras",
+              "urls": [
+                "https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"
+              ],
+              "sha256": "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+              "strip_prefix": "swift-nio-extras-1.4.0/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_nio_extras/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_protobuf": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_protobuf",
+              "urls": [
+                "https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"
+              ],
+              "sha256": "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+              "strip_prefix": "swift-protobuf-1.20.2/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_protobuf/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_ssl": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_nio_ssl",
+              "urls": [
+                "https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"
+              ],
+              "sha256": "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+              "strip_prefix": "swift-nio-ssl-2.23.0/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_atomics": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_atomics",
+              "urls": [
+                "https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"
+              ],
+              "sha256": "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+              "strip_prefix": "swift-atomics-1.1.0/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_atomics/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_http2": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_nio_http2",
+              "urls": [
+                "https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"
+              ],
+              "sha256": "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+              "strip_prefix": "swift-nio-http2-1.26.0/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_nio_http2/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_nio_transport_services": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_nio_transport_services",
+              "urls": [
+                "https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"
+              ],
+              "sha256": "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+              "strip_prefix": "swift-nio-transport-services-1.15.0/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_index_import": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~build_bazel_rules_swift_index_import",
+              "build_file": "@@rules_swift~1.18.0//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+              "canonical_id": "index-import-5.8",
+              "urls": [
+                "https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"
+              ],
+              "sha256": "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15"
+            }
+          },
+          "com_github_apple_swift_nio": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_nio",
+              "urls": [
+                "https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"
+              ],
+              "sha256": "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+              "strip_prefix": "swift-nio-2.42.0/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_nio/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_log": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_log",
+              "urls": [
+                "https://github.com/apple/swift-log/archive/1.4.4.tar.gz"
+              ],
+              "sha256": "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+              "strip_prefix": "swift-log-1.4.4/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_log/BUILD.overlay"
+            }
+          },
+          "com_github_apple_swift_collections": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~com_github_apple_swift_collections",
+              "urls": [
+                "https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"
+              ],
+              "sha256": "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+              "strip_prefix": "swift-collections-1.0.4/",
+              "build_file": "@@rules_swift~1.18.0//third_party:com_github_apple_swift_collections/BUILD.overlay"
+            }
+          },
+          "build_bazel_rules_swift_local_config": {
+            "bzlFile": "@@rules_swift~1.18.0//swift/internal:swift_autoconfiguration.bzl",
+            "ruleClassName": "swift_autoconfiguration",
+            "attributes": {
+              "name": "rules_swift~1.18.0~non_module_deps~build_bazel_rules_swift_local_config"
             }
           }
         }

--- a/examples/io_grpc/bazel_build_java/MODULE.bazel
+++ b/examples/io_grpc/bazel_build_java/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.1",
 )
 
-bazel_dep(name = "dagger-grpc", version = "0.1")
+bazel_dep(name = "dagger-grpc", version = "0.1.0")
 local_path_override(
     module_name = "dagger-grpc",
     path = "../../..",

--- a/examples/io_grpc/bazel_build_java/MODULE.bazel.lock
+++ b/examples/io_grpc/bazel_build_java/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "7a8b0762184a7b34e9655925a3c8abeb2c1419c67def7e4b29dffe288dcd4d47",
+  "moduleFileHash": "8ff232adc9a287a2ce2682615d9539791b3d49ff331ce01084d81775c262a478",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -13,7 +13,7 @@
     "compatibilityMode": "ERROR"
   },
   "localOverrideHashes": {
-    "dagger-grpc": "fd69814250cfd707f8c27106ce7af3ef9bead5c6d7ee90b671756ae1d8fcd959",
+    "dagger-grpc": "6955675ada70c601f91f68dd0ac5e4e865221689b81b83f6ae07d1e046b7a99d",
     "bazel_tools": "922ea6752dc9105de5af957f7a99a6933c0a6a712d23df6aad16a9c399f7e787"
   },
   "moduleDepGraph": {
@@ -117,7 +117,7 @@
     },
     "dagger-grpc@_": {
       "name": "dagger-grpc",
-      "version": "0.1",
+      "version": "0.1.0",
       "key": "dagger-grpc@_",
       "repoName": "dagger-grpc",
       "executionPlatformsToRegister": [],

--- a/examples/io_grpc/bazel_build_kt/MODULE.bazel
+++ b/examples/io_grpc/bazel_build_kt/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "0.1",
 )
 
-bazel_dep(name = "dagger-grpc", version = "0.1")
+bazel_dep(name = "dagger-grpc", version = "0.1.0")
 local_path_override(
     module_name = "dagger-grpc",
     path = "../../..",

--- a/examples/io_grpc/bazel_build_kt/MODULE.bazel.lock
+++ b/examples/io_grpc/bazel_build_kt/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "e1159a9d020cccefb71cea28ade12b9c8df2159f44863d4af5d4e3448f8cc454",
+  "moduleFileHash": "d73619f464d06b7b98b25f04b30c3c84e32e31f7badb48e2846454108cffc205",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -13,7 +13,7 @@
     "compatibilityMode": "ERROR"
   },
   "localOverrideHashes": {
-    "dagger-grpc": "fd69814250cfd707f8c27106ce7af3ef9bead5c6d7ee90b671756ae1d8fcd959",
+    "dagger-grpc": "6955675ada70c601f91f68dd0ac5e4e865221689b81b83f6ae07d1e046b7a99d",
     "bazel_tools": "922ea6752dc9105de5af957f7a99a6933c0a6a712d23df6aad16a9c399f7e787"
   },
   "moduleDepGraph": {
@@ -172,7 +172,7 @@
     },
     "dagger-grpc@_": {
       "name": "dagger-grpc",
-      "version": "0.1",
+      "version": "0.1.0",
       "key": "dagger-grpc@_",
       "repoName": "dagger-grpc",
       "executionPlatformsToRegister": [],

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# scripts/release.sh — Cut a dagger-grpc release.
+#
+# Usage:
+#   scripts/release.sh <version>            # e.g. 0.1.0
+#   scripts/release.sh --dry-run <version>  # validate only, no side effects
+#
+# What this script does:
+#   1. Validates all release criteria (see §CRITERIA below)
+#   2. Creates a GitHub release + tag via `gh release create`
+#   3. The publish.yaml workflow fires automatically on the release event,
+#      opening a draft BCR PR at geekinasuit/bazel-central-registry
+#
+# §CRITERIA — all must pass before tagging:
+#   - VERSION argument matches MODULE.bazel version field
+#   - Working copy is clean (no uncommitted changes)
+#   - HEAD commit is on main
+#   - bin/bazel build //... passes
+#   - bin/bazel test //... passes
+#   - Both example workspaces build and test cleanly
+#
+# §AGENT RELEASE RULES — an agent may run this script only when:
+#   - The user has explicitly provided the version to cut
+#   - The user has granted permission to push tags and create a release
+#   - All criteria above pass (script enforces this)
+#
+# Prerequisites (one-time human setup — see T16 plan):
+#   - geekinasuit/bazel-central-registry fork exists
+#   - BCR_PUBLISH_TOKEN secret set in repo settings
+#   - Google CLA signed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BAZEL="${REPO_ROOT}/bin/bazel"
+
+DRY_RUN=false
+VERSION=""
+
+# Parse arguments
+for arg in "$@"; do
+  case "${arg}" in
+    --dry-run) DRY_RUN=true ;;
+    --*)       echo "Unknown flag: ${arg}" >&2; exit 1 ;;
+    *)
+      if [[ -z "${VERSION}" ]]; then
+        VERSION="${arg}"
+      else
+        echo "Unexpected argument: ${arg}" >&2; exit 1
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "${VERSION}" ]]; then
+  echo "Usage: $0 [--dry-run] <version>   (e.g. 0.1.0)" >&2
+  exit 1
+fi
+
+TAG="v${VERSION}"
+PASS="[PASS]"
+FAIL="[FAIL]"
+INFO="[INFO]"
+
+echo "${INFO} Release criteria check for ${TAG}"
+echo ""
+
+ERRORS=0
+
+check() {
+  local desc="$1"
+  local result="$2"   # "ok" or error message
+  if [[ "${result}" == "ok" ]]; then
+    echo "${PASS} ${desc}"
+  else
+    echo "${FAIL} ${desc}: ${result}"
+    ERRORS=$((ERRORS + 1))
+  fi
+}
+
+# ── Criterion 1: VERSION matches MODULE.bazel ────────────────────────────────
+MODULE_VERSION="$(grep -m1 'version = ' "${REPO_ROOT}/MODULE.bazel" | sed 's/.*version = "\(.*\)".*/\1/')"
+if [[ "${MODULE_VERSION}" == "${VERSION}" ]]; then
+  check "MODULE.bazel version matches ${VERSION}" "ok"
+else
+  check "MODULE.bazel version matches ${VERSION}" \
+    "MODULE.bazel says \"${MODULE_VERSION}\"; expected \"${VERSION}\""
+fi
+
+# ── Criterion 2: Clean working copy ─────────────────────────────────────────
+JJ_STATUS="$(jj status 2>&1)"
+if echo "${JJ_STATUS}" | grep -q "^Working copy changes:"; then
+  check "Working copy is clean" "uncommitted changes present (run: jj status)"
+else
+  check "Working copy is clean" "ok"
+fi
+
+# ── Criterion 3: HEAD is on main ─────────────────────────────────────────────
+HEAD_BRANCHES="$(jj log --no-graph -r @ --template 'bookmarks' 2>/dev/null)"
+if echo "${HEAD_BRANCHES}" | grep -q "main"; then
+  check "HEAD commit is on main" "ok"
+else
+  check "HEAD commit is on main" "current @ does not have main bookmark (${HEAD_BRANCHES:-none})"
+fi
+
+# ── Criterion 4: CI green (build + test) ─────────────────────────────────────
+echo ""
+echo "${INFO} Running bin/bazel build //... (this may take a moment)"
+if "${BAZEL}" build //... > /tmp/release_build.log 2>&1; then
+  check "bin/bazel build //..." "ok"
+else
+  check "bin/bazel build //..." "build failed — see /tmp/release_build.log"
+fi
+
+echo "${INFO} Running bin/bazel test //..."
+if "${BAZEL}" test //... > /tmp/release_test.log 2>&1; then
+  check "bin/bazel test //..." "ok"
+else
+  check "bin/bazel test //..." "tests failed — see /tmp/release_test.log"
+fi
+
+# ── Criterion 5: Example workspaces ──────────────────────────────────────────
+for example in examples/io_grpc/bazel_build_java examples/io_grpc/bazel_build_kt; do
+  echo "${INFO} Building ${example}..."
+  if (cd "${REPO_ROOT}/${example}" && "${BAZEL}" build //... > /tmp/release_ex_build.log 2>&1); then
+    check "${example}: build" "ok"
+  else
+    check "${example}: build" "failed — see /tmp/release_ex_build.log"
+  fi
+  if (cd "${REPO_ROOT}/${example}" && "${BAZEL}" test //... > /tmp/release_ex_test.log 2>&1); then
+    check "${example}: test" "ok"
+  else
+    check "${example}: test" "failed — see /tmp/release_ex_test.log"
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+if [[ "${ERRORS}" -gt 0 ]]; then
+  echo "❌  ${ERRORS} criterion/criteria failed. Fix above issues before releasing."
+  exit 1
+fi
+
+echo "✅  All criteria passed for ${TAG}."
+echo ""
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "${INFO} --dry-run: stopping here. No tag or release created."
+  exit 0
+fi
+
+# ── Create GitHub release (also creates the tag) ──────────────────────────────
+echo "${INFO} Creating GitHub release ${TAG}..."
+gh release create "${TAG}" \
+  --repo geekinasuit/dagger-grpc \
+  --title "dagger-grpc ${TAG}" \
+  --generate-notes \
+  --draft=false
+
+echo ""
+echo "✅  Release ${TAG} created."
+echo "${INFO} The publish.yaml workflow will now open a draft BCR PR automatically."
+echo "${INFO} Monitor: gh run list --repo geekinasuit/dagger-grpc --workflow publish.yaml"
+echo "${INFO} BCR PR will appear at: https://github.com/geekinasuit/bazel-central-registry/pulls"

--- a/thoughts/shared/plans/T16-bcr-publication.compressed.md
+++ b/thoughts/shared/plans/T16-bcr-publication.compressed.md
@@ -1,0 +1,91 @@
+<!--COMPRESSED v1; source:T16-bcr-publication.md-->
+§META
+date:2026-04-21 author:agent ticket:T16 status:draft
+
+§ABBREV
+BCR=Bazel-Central-Registry bcr=bazelbuild/bazel-central-registry
+p2b=bazel-contrib/publish-to-bcr SRI=subresource-integrity
+lpo=local_path_override
+
+§GOAL
+Publish dagger-grpc to BCR so consumers use bazel_dep(name="dagger-grpc",version="X.Y.Z") without lpo or archive_override.
+
+§CONTEXT
+Module is bzlmod-ready (MODULE.bazel present). No prior releases, no tags, no BCR entry, no publish workflow. Version bumped 0.1→0.1.0 in this work. Examples use lpo for local dev; BCR CI needs lpo removed (handled via patch).
+
+§APPROACH
+Two tracks:
+1. Repo wiring — .bcr/ templates + publish.yaml + scripts/release.sh (code changes, PR)
+2. Onboarding — one-time human steps (fork BCR, CLA, PAT, secret) — cannot be automated
+
+Automation: p2b reusable workflow (v1.2.0) fires on release.published, reads .bcr/ templates, computes SRI hash, opens draft PR on BCR fork. Legacy GitHub App discontinued 2026-06-30; use GH Actions only.
+
+§BCR_ENTRY_FILES
+Per version: MODULE.bazel(verbatim) source.json(url+SRI) presubmit.yml patches/(optional)
+Module-level: metadata.json(maintainers,repository allowlist,versions[])
+
+§SOURCE_JSON_SCHEMA
+url: GitHub release asset URL
+integrity: sha256-<base64> (SRI)
+strip_prefix: <repo>-<version>
+patches: {filename: sha256-<base64>}  [if patches present]
+patch_strip: 1  [default]
+
+§PRESUBMIT
+matrix: platform[ubuntu2004] × bazel[7.x,8.x]
+tasks: build_library(//...) + test_java_example(bcr_test_module:examples/bazel_build_java) + test_kt_example(bcr_test_module:examples/bazel_build_kt)
+bcr_test_module uses examples after patch removes lpo
+
+§PATCH_STRATEGY
+.bcr/patches/examples_use_registry.patch removes lpo blocks from both example MODULE.bazel files.
+Examples committed with bazel_dep version matching root version → patch only removes lpo, no version rewrite.
+Update patch + example bazel_dep versions together on each release bump.
+
+§STEPS
+Phase1(repo wiring — this PR):
+  1a. MODULE.bazel version 0.1→0.1.0
+  1b. examples bazel_dep version 0.1→0.1.0
+  1c. .bcr/metadata.template.json (cgruber/331234)
+  1d. .bcr/source.template.json ({OWNER}/{REPO}/{TAG}/{VERSION} placeholders)
+  1e. .bcr/presubmit.yml (ubuntu×bazel7/8, build+test+examples)
+  1f. .bcr/patches/examples_use_registry.patch (remove lpo)
+  1g. .github/workflows/publish.yaml (p2b v1.2.0, draft:true, attest:false)
+  1h. scripts/release.sh (criteria check → gh release create)
+  1i. plans/T16-bcr-publication.md + .compressed.md
+  1j. T16+T17 github_issue fields patched (22,23)
+  1k. MODULE.bazel.lock regenerated
+
+Phase2(onboarding — human):
+  2a. Fork bazelbuild/bazel-central-registry → geekinasuit/bazel-central-registry
+  2b. Sign Google CLA
+  2c. Create Classic PAT (workflow+repo scopes); store as BCR_PUBLISH_TOKEN
+  [note: Fine-grained PATs cannot open PRs on public repos — must use Classic]
+
+Phase3(first release):
+  3a. scripts/release.sh 0.1.0 (or --dry-run first)
+  3b. Monitor publish.yaml: opens draft PR on geekinasuit/bazel-central-registry
+  3c. Review BCR entry; click Ready for Review → submits to bazelbuild/bazel-central-registry
+  3d. BCR maintainer approves first submission CI
+  3e. Verify: fresh project resolves bazel_dep(name="dagger-grpc",version="0.1.0")
+
+Phase4(example updates — parallel to 2/3):
+  4a. Test patch locally against the release archive
+  4b. Verify BCR CI passes with patched examples
+
+§RELEASE_CRITERIA (scripts/release.sh enforces):
+MODULE.bazel version matches tag | clean working copy | HEAD on main | bin/bazel build //... | bin/bazel test //... | both examples build+test
+
+§AGENT_RELEASE_RULES
+May cut release only when: user explicitly provides version; user grants tag+release-create permission; all criteria pass.
+
+§OPEN_QUESTIONS
+attest:false for v0.1.0; add later via bazel-contrib/release_ruleset
+BCR_PUBLISH_TOKEN: Classic PAT needed; Fine-grained won't work
+First submission: BCR maintainer manual approval required (one-time)
+source.template.json URL assumes named release asset; p2b defaults to auto-generated archive tarball if no asset matches — verify at first release
+
+§DONE
+[ ] publish.yaml fires on release and opens draft BCR PR
+[ ] BCR presubmit CI passes (all tasks green)
+[ ] bazel_dep(name="dagger-grpc",version="0.1.0") resolves in fresh project
+[ ] examples build+test after lpo patch applied

--- a/thoughts/shared/plans/T16-bcr-publication.md
+++ b/thoughts/shared/plans/T16-bcr-publication.md
@@ -1,0 +1,300 @@
+# Plan: Publish dagger-grpc to the Bazel Central Registry (T16)
+
+**Status:** draft — tentative; update as implementation proceeds  
+**Ticket:** `thoughts/shared/tickets/T16-publish-to-bazel-central-registry.md`  
+**Researched:** 2026-04-21
+
+---
+
+## 1. Overview
+
+Publishing to the BCR requires two distinct tracks that can proceed partly in parallel:
+
+1. **Release process** — a tagging convention, a release script, and criteria that allow an agent (or human) to cut a version safely
+2. **BCR wiring** — template files in this repo + a `publish-to-bcr` GitHub Actions workflow that opens a BCR PR automatically on each release
+
+The one-time **onboarding** steps (fork BCR, register as maintainer, get first PR approved by BCR maintainers) gate the very first publication but do not block building the release infrastructure.
+
+---
+
+## 2. Research Summary
+
+### BCR Entry Structure
+
+Each module version in the BCR lives at `modules/<name>/<version>/` and requires exactly four files:
+
+```
+modules/dagger-grpc/
+  metadata.json                   ← module-level (one per module, not per version)
+  0.1.0/
+    MODULE.bazel                  ← verbatim copy of the module's MODULE.bazel at that tag
+    source.json                   ← download URL + SRI integrity hash
+    presubmit.yml                 ← what BCR CI should build/test
+    patches/                      ← optional; .patch files applied to the archive
+```
+
+**metadata.json** (module-level, not version-level):
+```json
+{
+  "homepage": "https://github.com/geekinasuit/dagger-grpc",
+  "maintainers": [
+    {
+      "github": "<github-username>",
+      "github_user_id": <numeric-id>,
+      "name": "<Full Name>",
+      "email": "<email>"
+    }
+  ],
+  "repository": ["github:geekinasuit/dagger-grpc"],
+  "versions": [],
+  "yanked_versions": {}
+}
+```
+`versions` and `yanked_versions` are auto-managed; leave empty in the template.
+
+**source.json**:
+```json
+{
+  "integrity": "sha256-<base64-encoded-sha256-of-archive>",
+  "url": "https://github.com/geekinasuit/dagger-grpc/releases/download/v0.1.0/dagger-grpc-v0.1.0.tar.gz",
+  "strip_prefix": "dagger-grpc-0.1.0"
+}
+```
+- `integrity` uses SRI format. Computed: `sha256sum archive.tar.gz | xxd -r -p | base64`
+- URL must point to a **stable release asset** — GitHub auto-generated archive tarballs at `/archive/refs/tags/` are acceptable but named release assets are preferred for provenance/attestation support
+- `strip_prefix` is the top-level directory name inside the archive
+
+**presubmit.yml** (proposed for dagger-grpc):
+```yaml
+matrix:
+  platform: ["ubuntu2004"]
+  bazel: ["7.x", "8.x"]
+tasks:
+  build_library:
+    name: "Build dagger-grpc library"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "//..."
+  test_java_example:
+    name: "Java example (APT consumer)"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    bcr_test_module:
+      module_path: "examples/io_grpc/bazel_build_java"
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."
+  test_kt_example:
+    name: "Kotlin example (KSP consumer)"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    bcr_test_module:
+      module_path: "examples/io_grpc/bazel_build_kt"
+      build_targets:
+        - "//..."
+      test_targets:
+        - "//..."
+```
+
+Notes:
+- BCR CI runs on Buildkite (Linux/macOS Ubuntu). macOS can be added but costs more time.
+- Bazel 6.x support is probably not worth maintaining — dagger-grpc uses bzlmod features that require 7+.
+- The `bcr_test_module` tasks use the existing example workspaces. Before BCR submission the examples must be updated to use `bazel_dep` instead of `local_path_override` (so BCR CI resolves from the registry, not local). A patch can handle this — see §4.
+
+### publish-to-bcr (Automation Tool)
+
+`bazel-contrib/publish-to-bcr` is a **GitHub Actions reusable workflow** that:
+1. Triggers on a repository release event (or workflow_dispatch for manual retry)
+2. Reads `.bcr/` template files from the ruleset repo
+3. Computes the archive integrity hash
+4. Opens a draft PR against `bazelbuild/bazel-central-registry` (or a fork) with the correctly-formed BCR entry
+
+**Important:** The legacy GitHub App that did this is being discontinued **June 30, 2026**. The GH Actions workflow is the current supported path.
+
+Required setup:
+- A fork of `bazelbuild/bazel-central-registry` under the `geekinasuit` org (for the workflow to push to)
+- A "Classic" GitHub PAT with `workflow` + `repo` scopes, stored as `BCR_PUBLISH_TOKEN` in repo secrets
+- `.bcr/` directory in this repo with template files (see §3)
+- A `.github/workflows/publish.yaml` that calls the reusable workflow on release
+
+### Onboarding Requirements (One-Time)
+
+1. **Fork the BCR**: create `geekinasuit/bazel-central-registry` as a fork of `bazelbuild/bazel-central-registry`
+2. **CLA**: the person opening the first BCR PR must have signed the Google CLA (required by BCR)
+3. **First-submission review**: new modules require BCR maintainer approval to unblock their CI. This is a one-time manual review — after that, the module maintainers can approve their own version additions
+4. **PAT creation**: create a Classic PAT (not fine-grained — fine-grained can't open PRs on public repos) with `workflow` + `repo` scopes, store as `BCR_PUBLISH_TOKEN`
+
+---
+
+## 3. Files to Add to This Repo
+
+### `.bcr/metadata.template.json`
+```json
+{
+  "homepage": "https://github.com/geekinasuit/dagger-grpc",
+  "maintainers": [
+    {
+      "github": "FILL_IN",
+      "github_user_id": 0,
+      "name": "FILL_IN",
+      "email": "FILL_IN"
+    }
+  ],
+  "repository": ["github:geekinasuit/dagger-grpc"],
+  "versions": [],
+  "yanked_versions": {}
+}
+```
+
+### `.bcr/source.template.json`
+```json
+{
+  "integrity": "",
+  "strip_prefix": "dagger-grpc-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}
+```
+`{OWNER}`, `{REPO}`, `{TAG}`, `{VERSION}` are substituted by publish-to-bcr at release time.
+
+### `.bcr/presubmit.yml`
+The presubmit.yml shown in §2 above. It should live at `.bcr/presubmit.yml` (publish-to-bcr copies it into the BCR entry).
+
+### `.bcr/patches/` (optional, likely needed)
+The examples currently use `local_path_override` to reference the root module. For BCR testing the examples must use `bazel_dep`. A patch file that replaces the `local_path_override` block in each example's MODULE.bazel with `bazel_dep(name="dagger-grpc", version="{VERSION}")` can be applied by BCR CI. Alternatively, the examples can be updated to conditionally use one or the other — or maintained as two copies.
+
+**Recommendation:** Keep `local_path_override` in the committed example files (for local development) and supply a `.bcr/patches/` patch that switches to `bazel_dep`. This way examples work locally without changes and BCR CI sees the registry-resolved version.
+
+### `.github/workflows/publish.yaml`
+```yaml
+name: Publish to BCR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to publish"
+        required: true
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v0.2.2
+    with:
+      tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
+      registry_fork: geekinasuit/bazel-central-registry
+      attest: false        # set true once release_ruleset workflow is in place
+      draft: true          # opens BCR PR as draft; maintainer clicks "Ready for review"
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}
+```
+
+---
+
+## 4. Release Process Design
+
+### Version Convention
+
+- **Format:** `v<major>.<minor>.<patch>` (semver, v-prefix) — e.g. `v0.1.0`
+- **MODULE.bazel version field:** strip the `v` — e.g. `version = "0.1.0"`
+- These must match: the tag, the MODULE.bazel version, and the `strip_prefix` in source.template.json
+- Current MODULE.bazel says `version = "0.1"` — before first release, bump to `version = "0.1.0"` for full semver compatibility
+
+### Release Criteria (gates that must pass before cutting a release)
+
+All of the following must be true:
+
+1. **CI green on main** — all jobs in `ci.yaml` pass on the HEAD commit being tagged
+2. **MODULE.bazel version matches intended tag** — `version = "X.Y.Z"` in MODULE.bazel matches the `vX.Y.Z` tag being cut
+3. **MODULE.bazel.lock is current** — lock file matches MODULE.bazel (not drifted)
+4. **No open HIGH-priority tickets blocking release** — check `thoughts/shared/tickets/overview.md`
+5. **Both example workspaces build and test cleanly** — `bin/bazel build //...` + `bin/bazel test //...` from each example directory
+
+### Release Script (`scripts/release.sh`)
+
+A shell script (not a Bazel target) that an agent or human can run to perform a release. It should:
+
+1. Verify the criteria above (exit non-zero if any fail)
+2. Update `MODULE.bazel` version field to the target version
+3. Regenerate `MODULE.bazel.lock` (run `bin/bazel mod deps` or equivalent)
+4. Commit the version bump (`jj commit` / `git commit`)
+5. Create the tag (`jj tag` or `git tag -a vX.Y.Z`)
+6. Push the tag (`jj git push --tags` or `git push --tags`)
+7. Create the GitHub release via `gh release create vX.Y.Z --generate-notes`
+
+The publish-to-bcr workflow fires automatically on the `release.published` event.
+
+### Agent Release Criteria
+
+For an agent to perform a release autonomously (without human confirmation on each step), the following must be explicitly granted by the user in advance:
+
+- Permission to push tags to the remote
+- Permission to create a GitHub release
+- A specific version number to cut (agent does not choose versions unilaterally)
+
+The agent must still verify all release criteria and stop with a report if any fail.
+
+---
+
+## 5. Implementation Sequence
+
+```
+Phase 1 — Repo wiring (no external dependencies)
+  1a. Bump MODULE.bazel version to "0.1.0"
+  1b. Add .bcr/ template files (metadata.template.json, source.template.json, presubmit.yml)
+  1c. Write scripts/release.sh
+  1d. Add .github/workflows/publish.yaml (the BCR publish workflow)
+
+Phase 2 — Onboarding (requires human action)
+  2a. Fork bazelbuild/bazel-central-registry → geekinasuit/bazel-central-registry
+  2b. Sign Google CLA (person who will open first BCR PR)
+  2c. Create Classic PAT with workflow+repo scopes
+  2d. Add BCR_PUBLISH_TOKEN to repo secrets
+
+Phase 3 — First release + BCR submission
+  3a. Run release script for v0.1.0 (or use release workflow)
+  3b. Monitor publish-to-bcr: it opens a draft PR on geekinasuit/bazel-central-registry fork
+  3c. Review the generated BCR entry, click "Ready for Review" (submits to bazelbuild/bazel-central-registry)
+  3d. BCR maintainers review first submission, approve CI, merge
+  3e. Verify: bazel_dep(name="dagger-grpc", version="0.1.0") resolves in a fresh project
+
+Phase 4 — Example updates (can parallel Phase 2/3)
+  4a. Author the patch(es) for example MODULE.bazel files (local_path_override → bazel_dep)
+  4b. Add patches to .bcr/patches/
+  4c. Update presubmit.yml if needed after patch testing
+```
+
+---
+
+## 6. Open Questions
+
+- **Who is the BCR maintainer?** The `metadata.template.json` needs a GitHub username and numeric user ID. This is the identity that BCR will notify on new version PRs and who can approve them.
+- **attest: true or false?** Attestation (SLSA provenance) requires using `bazel-contrib/release_ruleset` as the release workflow. Is that desirable for v0.1.0, or add later?
+- **Bazel 6.x support in presubmit.yml?** dagger-grpc uses bzlmod and Kotlin rules that require Bazel 7+. Recommend dropping Bazel 6.x from the matrix.
+- **macOS in BCR CI matrix?** BCR CI runs on macOS are slower and costlier. Recommend Ubuntu-only for the initial submission, add macOS later.
+- **Release tarball vs auto-generated archive?** The publish-to-bcr tool defaults to using the GitHub auto-generated tarball (`/archive/refs/tags/`). This is acceptable. Named release assets are only needed if attestation is enabled.
+- **MODULE.bazel.lock drift**: currently drifted intentionally (research phase). Must be resolved before cutting a release.
+
+---
+
+## 7. Success Criteria
+
+- [ ] `bin/bazel test //...` passes from root and both examples at v0.1.0 tag
+- [ ] `publish.yaml` workflow fires on release and opens a draft BCR PR automatically
+- [ ] BCR PR passes all presubmit checks
+- [ ] `bazel_dep(name = "dagger-grpc", version = "0.1.0")` resolves in a fresh external project
+- [ ] Example workspaces are updated to use `bazel_dep` and verified to work
+
+---
+
+## References
+
+- [BCR contribution guide](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md)
+- [BCR policies](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/bcr-policies.md)
+- [publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr)
+- `MODULE.bazel:7-10` — current version declaration
+- `examples/io_grpc/bazel_build_java/MODULE.bazel` — local_path_override to patch
+- `examples/io_grpc/bazel_build_kt/MODULE.bazel` — local_path_override to patch
+- `.github/workflows/ci.yaml` — existing CI to confirm passes before release

--- a/thoughts/shared/tickets/T16-publish-to-bazel-central-registry.md
+++ b/thoughts/shared/tickets/T16-publish-to-bazel-central-registry.md
@@ -4,6 +4,7 @@ title: Publish to Bazel Central Registry
 priority: medium
 phase: distribution
 status: open
+github_issue: 22
 ---
 
 ## Summary

--- a/thoughts/shared/tickets/T17-publish-maven-artifacts.md
+++ b/thoughts/shared/tickets/T17-publish-maven-artifacts.md
@@ -4,6 +4,7 @@ title: Publish Maven-compatible artifacts to Maven Central
 priority: medium
 phase: distribution
 status: open
+github_issue: 23
 ---
 
 ## Summary


### PR DESCRIPTION
## Prerequisites
- [ ] N/A — no parent PR

## Summary
- Bumps `dagger-grpc` version `0.1` → `0.1.0` in `MODULE.bazel` and both example workspaces; regenerates lock files
- Adds `.bcr/` template files (`metadata.template.json`, `source.template.json`, `presubmit.yml`, `patches/examples_use_registry.patch`) for automated BCR entry generation
- Adds `.github/workflows/publish.yaml` wiring `bazel-contrib/publish-to-bcr@v1.2.0` — fires on `release.published`, opens a draft BCR PR at `geekinasuit/bazel-central-registry` automatically
- Adds `scripts/release.sh` — validates all release criteria then calls `gh release create`
- Adds `thoughts/shared/plans/T16-bcr-publication.md` + `.compressed.md`
- Patches `T16`/`T17` ticket frontmatter with `github_issue` fields (see #22, #23)

## Validation performed
- [x] `bin/bazel test //...` (root) — 4/4 tests pass after version bump
- [x] `bin/bazel build //...` (both example workspaces) — clean after bazel_dep version update
- [x] `MODULE.bazel.lock` regenerated via `bazel mod deps --lockfile_mode=update`
- [ ] ansible --check passed (N/A — no infra change)
- [ ] kubectl dry-run passed (N/A)
- [ ] sops decrypt verified (N/A)

## Affected machines / services
- N/A for build infra; affects consumers when v0.1.0 is published to BCR

## Deployment steps (POST-MERGE)
One-time human setup required before first release (see plan Phase 2):
1. Fork `bazelbuild/bazel-central-registry` → `geekinasuit/bazel-central-registry`
2. Sign Google CLA
3. Create Classic PAT (workflow + repo scopes) → store as `BCR_PUBLISH_TOKEN` repo secret
   (Fine-grained PATs cannot open PRs on public repos — must be Classic)

Then to cut a release: `scripts/release.sh 0.1.0` (or `--dry-run` first)

## Tickets addressed
- see #22 (T16 — Publish to Bazel Central Registry)

## Rollback
- Revert the two commits; no external state created until `scripts/release.sh` is run
