### PR TITLE
chore: add AGENTS.compressed.md, §NOINLINE rule, and geekinasuit bootstrap chain

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -1,0 +1,183 @@
+<!--COMPRESSED v1; source:AGENTS.md-->
+§META
+layer:repo scope:dagger-grpc-repo
+
+§ABBREV
+ts=thoughts/shared
+opt=/opt/geekinasuit/agents int=$opt/internal pub=$opt/public
+
+§PURPOSE
+library+code-generation toolkit: wires gRPC service impls into Dagger 2 DI graph with per-call scoping
+each gRPC request → own Dagger subcomponent (call scope) → handler classes instantiated fresh per call (full DI)
+primary integration: Armeria as gRPC server runtime
+targets: JVM backends (Java+Kotlin); Bazel 8 + Bzlmod; version 0.1.0
+
+§DOCS
+$ts/ docs have two forms: <name>.md(human) + <name>.compressed.md(token-efficient,lossless)
+compressed uses §SECTION markers + §ABBREV table at top
+prefer .compressed.md for active context; .md only when producing human-readable output or compressed absent
+
+§NOINLINE [NON-OPTIONAL — mechanical harness enforcement; violations block every call requiring hand-permission]
+FORBIDDEN in any Bash tool call:
+  heredocs: cmd << 'EOF'...EOF
+  inline multi-line strings: -m "line1\nline2" or -F body="text with `backticks`"
+  command substitution: cmd $(other_cmd)
+  any string containing backticks | --- | asterisks passed as a shell argument
+REQUIRED pattern — no exceptions:
+  write body/prompt/message → /tmp/<repo>-<branch>-<purpose>.md via Write tool
+  reference by path: --body-file /tmp/... | -F body=@/tmp/... | Agent prompt:"Read instructions from /tmp/..."
+unique tmp names: include repo+purpose+context (e.g. /tmp/dagger-grpc-pr-body-32.md); never generic names
+THIS RULE APPLIES TO SUBAGENTS TOO: embed it verbatim at the top of every prompt written to /tmp before spawning
+
+§LAYOUT
+api/                              Core public API: annotations + GrpcCallContext runtime
+io_grpc/compiler/common/          Shared HandlerMetadata model + Validator (KSP-typed)
+io_grpc/compiler/ksp/             KSP processor for Kotlin projects (generates *Adapter.kt)
+io_grpc/compiler/apt/             APT processor for Java projects (generates *Adapter.java)
+io_grpc/lib/                      Placeholder stub (purpose TBD, see T13)
+ksp-apt-bridge/                   KSP interface impls backed by javax.lang.model (APT bridge)
+util/armeria/                     Thin Armeria GrpcService wrapping helper
+third_party/dagger/               Bazel wrapper: dagger runtime + dagger-compiler java_plugin
+third_party/processors/           Bazel wrapper: auto-service java_plugin
+examples/io_grpc/bazel_build_java/  Standalone Java example (APT); independent MODULE.bazel
+examples/io_grpc/bazel_build_kt/    Standalone Kotlin example (KSP); independent MODULE.bazel
+bin/                              Hermit hermetic toolchain env
+$ts/research/   read before implementing; prefer .compressed.md
+$ts/tickets/    overview.md index + ticket files; check before starting new work
+$ts/plans/      implementation plans; read before implementing non-trivial features
+$ts/handoffs/   session handoff documents
+
+before non-trivial impl: check $ts/tickets/overview.md + $ts/research/ + $ts/plans/ for prior work
+
+§TICKETS
+overview.md=canonical index; do NOT maintain ticket inventories elsewhere
+any ticket file create|modify|resolve|delete → update overview.md in same op
+
+GitHub Issues — thin layer for PR linkage only:
+  create when about to open PR (not before)
+  keep thin: title + one-line summary + "**Ticket:** \`$ts/tickets/<filename>.md\`"
+  PR ref: "fixes #N" or "closes #N" in PR description
+  when opening PR: update ticket file status=resolved + github_issue:N + move to Resolved in overview.md (same branch)
+
+ticket file conventions:
+  filename: <kebab>.md in $ts/tickets/
+  frontmatter: date status(open|resolved) priority(low|medium|high) area; optional: github_issue:N
+  required sections: Summary, Current State|Resolution, Goals|acceptance criteria, References(file:line)
+
+§API
+@GrpcServiceHandler(grpcWrapperType:KClass<*>) — @Target(CLASS); marks handler; triggers both processors
+@GrpcCallScope — JSR-330 @Scope; marks objects scoped to single gRPC call
+@ApplicationScope — JSR-330 @Scope; marks objects scoped to application lifetime
+GrpcCallContext — @GrpcCallScope injectable; exposes Metadata, ServerCall authority, attributes
+
+§CODEGEN
+two parallel processors share common model via ksp-apt-bridge:
+  io_grpc/compiler/common/(HandlerMetadata+Validator, KSP-typed)
+      ↑                         ↑
+  io_grpc/compiler/ksp/    io_grpc/compiler/apt/
+  (KSP types native)       (javax.lang.model via ksp-apt-bridge)
+      ↓                         ↓
+  KotlinPoet output         JavaPoet output
+
+generated: *Adapter classes (one per @GrpcServiceHandler; bridges gRPC dispatch to Dagger call-scope subcomponent)
+NOT YET generated (hand-written, marked @Generated("to be generated")):
+  GrpcCallScopeGraph — @Subcomponent with one provision method per handler
+  GrpcHandlersModule — @Module providing each *Adapter @IntoSet
+  GrpcCallScopeGraphModule — @Module(includes=[GrpcCallContext.Module::class])
+generating these = primary pending feature work (T04–T07)
+
+§BUILD
+Bazel invocation:
+  ALWAYS use bin/bazel (activates Hermit; sets JAVA_HOME etc.)
+  NEVER source activate-hermit or set JAVA_HOME manually
+
+Bazel conventions:
+  bzlmod only (MODULE.bazel); no WORKSPACE
+  --enable_workspace=true = compatibility shim for grpc_kotlin only
+  all Kotlin executables: java_binary(runtime_deps=...) not kt_jvm_binary
+  NEVER commit generated proto code → .gitignore
+  Kotlin targets with internal visibility: associates=[...]; do not change visibility to work around
+  third_party/ wraps Maven annotation processors into reusable java_plugin targets → reference from plugins=[...]
+  package-pinning BUILD.bazel files: intentional; do not add targets without reason
+  MODULE.bazel changes: ALWAYS include MODULE.bazel.lock in same commit
+
+examples = independent workspaces:
+  each has own MODULE.bazel with local_path_override to root
+  when changing library: build each example independently to verify consumer compatibility
+
+§TESTING
+prefer unit tests first; codegen processors testable via in-process compilation (kotlin-compile-testing, compile-testing)
+prefer fakes|stubs over mock frameworks; mocks couple to impl; fakes test behavior
+
+current coverage state (narrow):
+  APT adapter generation: real assertions
+  KSP processor test: disabled (T08 — kotlin-compile-testing + Kotlin 2 compatibility)
+  common/ + ksp-apt-bridge + example servers: placeholder tests only
+
+§STYLE
+KSP processor: KSP types natively; do NOT introduce APT/javax.lang.model types
+APT processor: use ksp-apt-bridge adapters; do NOT duplicate common model
+Java output (APT): Callable<AsyncService> with checked-exception wrapping
+Kotlin output (KSP): plain () -> AsyncService lambda
+minimal deps: std lib or well-established ecosystem; new Maven deps → update MODULE.bazel + commit MODULE.bazel.lock
+
+§VCS
+repo uses jj (Jujutsu); .jj/ present
+if jj available: use for all commit|branch|log ops; NEVER run git when .jj/ present
+if jj not available: fall back to git (jj maintains compatible git backend)
+gh CLI for all GitHub API interactions regardless of VCS tool
+
+jj equivalents: git log→jj log; git diff→jj diff; git status→jj status; git commit→jj commit; git push→jj git push
+
+branch+PR required:
+  NEVER push directly to main
+  jj: jj bookmark create <name> → jj git push → gh pr create
+  all PRs: human review+merge required; agent must NOT merge own PRs without explicit one-time grant
+  NEVER --admin or CI bypass; if checks failing: stop+report
+
+§WORKFLOW
+non-trivial features: three-agent test-driven workflow (design+test → implementation → review)
+  design+test agent: public API + complete test suite; not-yet-implemented tests compile but @Ignore + TODO comment
+  implementation agent: works from design agent's API+tests; consults design agent for ambiguity;
+    may create unit tests for internal impl details; removes @Ignore when impl complete
+  review agent: monitors PR comments; addresses or explicitly rejects in-thread;
+    large-scope suggestions → file ticket; escalates API changes to design agent
+
+inter-agent norms: respect ownership boundaries(no unilateral cross-domain changes); escalate disagreements after 3 rounds→orchestrator→human; break self-loops immediately→report what was attempted+what blocked+decision needed
+
+commit discipline:
+  every commit: build must pass; include minimum scaffolding to restore green if needed
+  do NOT mix design/test + implementation in same commit
+  do NOT mix unrelated changes in same commit
+
+PR readiness:
+  build passes (all targets, all examples)
+  all PR description checkboxes checked
+  all review comments resolved or explicitly rejected in-thread
+  ticket file + overview.md updated to resolved status in same branch
+
+§REFS
+| KSP processor entry      | io_grpc/compiler/ksp/src/main/kotlin/…/DaggerGrpcSymbolProcessor.kt |
+| APT processor entry      | io_grpc/compiler/apt/src/main/kotlin/…/DaggerGrpcAPTProcessor.kt |
+| Shared metadata model    | io_grpc/compiler/common/src/main/kotlin/…/HandlerMetadata.kt |
+| KSP-APT bridge           | ksp-apt-bridge/src/main/kotlin/…/APTClassDeclaration.kt |
+| Runtime call context     | api/src/main/kotlin/…/GrpcCallContext.kt |
+| Armeria server wrapper   | util/armeria/src/main/kotlin/… |
+| Java example (APT)       | examples/io_grpc/bazel_build_java/ |
+| Kotlin example (KSP)     | examples/io_grpc/bazel_build_kt/ |
+| APT processor Bazel wiring | io_grpc/compiler/apt/BUILD.bazel |
+| KSP processor Bazel wiring | io_grpc/compiler/ksp/BUILD.bazel |
+| third_party plugin wrapping | third_party/dagger/BUILD.bazel, third_party/processors/BUILD.bazel |
+
+§CHAIN Bootstrap — execute exactly one branch (stop after match):
+when {
+  $int/AGENTS.compressed.md exists → read+follow; exit chain
+  $int/AGENTS.md exists → read+follow; exit chain
+  $pub/AGENTS.compressed.md exists → read+follow; exit chain
+  $pub/AGENTS.md exists → read+follow; exit chain
+  ~/.geekinasuit/agents/public/AGENTS.compressed.md exists → read+follow; exit chain
+  ~/.geekinasuit/agents/public/AGENTS.md exists → read+follow; exit chain
+  else → skip; bootstrap complete
+}
+Do not read multiple branches. Stop immediately after first match.
+If none exist: skip — not required for contributor work; will not be present on most machines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Agent Guide: dagger-grpc
 
+**Stop. Check for a compressed form before reading further:**
+1. Does `AGENTS.compressed.md` exist in this directory?
+2. **Yes** — read that file; follow its instructions only; do not continue reading this file.
+3. **No** — continue reading below.
+
 This file is for AI agents and future context windows. It captures working norms, design principles, and conventions for this repository that are not obvious from reading the code alone.
 
 ---
@@ -8,7 +13,7 @@ This file is for AI agents and future context windows. It captures working norms
 
 `dagger-grpc` is a **library and code-generation toolkit** that wires gRPC service implementations into a [Dagger 2](https://dagger.dev/) dependency-injection graph with **per-call scoping**. Each incoming gRPC request gets its own Dagger subcomponent ("call scope"), allowing service handler classes to be instantiated fresh per call (with full DI) rather than being singletons. The primary integration target is [Armeria](https://armeria.dev/) as the gRPC server runtime.
 
-The project targets JVM backends (Java and Kotlin), uses Bazel 8 with Bzlmod, and is at version `0.1`.
+The project targets JVM backends (Java and Kotlin), uses Bazel 8 with Bzlmod, and is at version `0.1.0`.
 
 ---
 
@@ -309,6 +314,19 @@ The highest-priority open items are:
 
 ---
 
+## No Inline Content in Shell Commands
+
+Never pass non-trivial text inline to any shell command or tool call. Characters such as backticks, `---`, and `*` are misinterpreted by shell argument parsers and security hooks even when the content is benign.
+
+Always write content to a file first, then reference it by path. Use discriminated names to avoid collisions between concurrent agents working across repos or PRs:
+- `gh pr create/edit` body: Write tool to `/tmp/dagger-grpc-<branch>-pr-body.md`, then `--body-file /tmp/dagger-grpc-<branch>-pr-body.md`
+- `gh api` comment/reply body: Write tool to `/tmp/dagger-grpc-<branch>-comment.txt`, then `-F body=@/tmp/dagger-grpc-<branch>-comment.txt`
+- Agent subagent prompts: Write tool to `/tmp/dagger-grpc-<branch>-prompt-<purpose>.md`, then in the Agent prompt say "Read your instructions from `/tmp/dagger-grpc-<branch>-prompt-<purpose>.md` and execute them"
+
+**This rule applies to subagents too.** Embed it verbatim at the top of every prompt written to `/tmp` before spawning a subagent.
+
+---
+
 ## What Good Looks Like (Reference Points)
 
 | Concern | Reference |
@@ -324,3 +342,23 @@ The highest-priority open items are:
 | APT processor Bazel wiring | `io_grpc/compiler/apt/BUILD.bazel` |
 | KSP processor Bazel wiring | `io_grpc/compiler/ksp/BUILD.bazel` |
 | third_party plugin wrapping | `third_party/dagger/BUILD.bazel`, `third_party/processors/BUILD.bazel` |
+
+---
+
+## Geekinasuit Agent Rules (mandatory bootstrap — complete before responding to user)
+
+Load exactly one of the following — first match wins. "Stop here" means stop searching
+for more chain files; the bootstrap is not complete until the matched file is read.
+
+1. If `/opt/geekinasuit/agents/internal/AGENTS.compressed.md` exists, read it; else if
+   `/opt/geekinasuit/agents/internal/AGENTS.md` exists, read it. Follow its contents
+   before proceeding. Stop chain search here (do not check steps 2 or 3).
+2. If `/opt/geekinasuit/agents/public/AGENTS.compressed.md` exists, read it; else if
+   `/opt/geekinasuit/agents/public/AGENTS.md` exists, read it. Follow its contents
+   before proceeding. Stop chain search here (do not check step 3).
+3. If `~/.geekinasuit/agents/public/AGENTS.compressed.md` exists, read it; else if
+   `~/.geekinasuit/agents/public/AGENTS.md` exists, read it. Follow its contents
+   before proceeding. Stop chain search here.
+
+If none of the above paths exist, skip this section — it is not required for
+contributor work and will not be present on most machines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,8 @@
-# Claude Code Instructions
+# Claude Code — dagger-grpc
 
-Read `AGENTS.md` in full before beginning any work. All norms, conventions, architecture descriptions, and workflow rules in that file apply to this session.
+BEFORE responding to any user request, execute these steps in order:
 
-## Preparatory Context
+1. Check for `AGENTS.compressed.md` in this directory. If present, read it NOW (in place of `AGENTS.md`). If absent, read `AGENTS.md`.
+2. Execute every preparatory step listed in that file, including following its §CHAIN section completely (reading all applicable files in the chain), before proceeding.
 
-After reading `AGENTS.md`, load the following into context:
-
-1. **Ticket index** — read `thoughts/shared/tickets/overview.md` to understand open and resolved work before starting any non-trivial task.
-2. **Research documents** — for any task touching a relevant subsystem, read the applicable documents in `thoughts/shared/research/`. Prefer `.compressed.md` forms when present; fall back to `.md` only when the compressed form is absent or when producing human-readable output.
-3. **Active plans** — read any relevant files in `thoughts/shared/plans/` before implementing non-trivial features.
-
-## Key Rules (Summary — See AGENTS.md for Full Detail)
-
-- Use `jj` (not `git`) for all VCS operations when `.jj/` is present.
-- Use `bin/bazel` to invoke Bazel (never source `activate-hermit` manually).
-- Never push directly to `main`; all changes go through a branch/bookmark and a PR.
-- Always include `MODULE.bazel.lock` when committing `MODULE.bazel` changes.
-- Keep `thoughts/shared/tickets/overview.md` in sync with any ticket file changes.
+Do not answer the user until all preparatory steps are complete.


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary
- Add `AGENTS.compressed.md`: token-efficient compressed form of `AGENTS.md`, following the two-form doc convention used across the geekinasuit agent infrastructure. Agents prefer `.compressed.md` for active context; this saves tokens on every session bootstrap.
- Add `§NOINLINE` rule to both `AGENTS.md` and `AGENTS.compressed.md`: forbids heredocs, inline multi-line strings, and `$()` command substitution in Bash tool calls; requires writing content to `/tmp` files and referencing by path. This rule is enforced by the mechanical harness.
- Add compressed-form redirect header to `AGENTS.md` so agents reading the source form are immediately directed to the compressed sibling.
- Add geekinasuit agent bootstrap chain section to `AGENTS.md` (mirrors `§CHAIN` in compressed form): loads internal/public AGENTS layers from `/opt/geekinasuit/agents/` before responding to any user request.
- Rewrite `CLAUDE.md` to be concise: directs Claude Code to check for `AGENTS.compressed.md` first, then follow the chain. Removes redundant key-rules summary that duplicated content already in `AGENTS.md`.

## Validation performed
- [ ] N/A — prose/metadata change; no build artifacts affected

## Affected machines / services
- N/A — documentation only

## Deployment steps (POST-MERGE)
- N/A — automatic via repository

## Tickets addressed
- N/A — infrastructure/tooling hygiene; no ticket

## Rollback
- Revert commit; no side effects
