### PR TITLE
docs(T04): ADR for generated module and subcomponent shape

### DIFF
--- a/thoughts/shared/tickets/T04-design-module-generation.md
+++ b/thoughts/shared/tickets/T04-design-module-generation.md
@@ -16,40 +16,265 @@ Before implementing module generation (T05/T06), nail down the exact shape of wh
 
 Several open questions affect the generated API surface. Answering them up front avoids rework in T05/T06/T07.
 
-## Open Design Questions
+---
 
-### 1. Should `GrpcCallScopeGraph.Supplier` be a library interface in `api/`?
+## Decisions (confirmed)
 
-The `Supplier` nested interface is always the same shape: `fun callScope(): GrpcCallScopeGraph` (or its equivalent). If it's part of the runtime API rather than generated, users can implement it directly in their `ApplicationGraph` component without depending on any generated type. This avoids a circular dependency between the generated subcomponent and the module that uses it.
+### Q1 — No `Supplier` interface; use `@Subcomponent.Factory`
 
-**Options:**
-- A: Generate `Supplier` as a nested interface inside the generated `GrpcCallScopeGraph`
-- B: Define `GrpcCallScopeGraph.Supplier` (or a renamed equivalent) as a library interface in `api/`
+**Decision:** Drop the `GrpcCallScopeGraph.Supplier` nested interface entirely. Use `@Subcomponent.Factory` instead.
 
-### 2. Should `GrpcCallScopeGraphModule` be generated?
+**Rationale:** `@Subcomponent.Factory` was designed for exactly this pattern. When `GrpcCallScopeGraphModule` declares `subcomponents = [GrpcCallScopeGraph::class]`, Dagger automatically makes `GrpcCallScopeGraph.Factory` injectable in the parent component — no explicit binding, no user-written module needed. This eliminates `Supplier` from the generated API surface and removes all user boilerplate from the wiring.
 
-It's trivially always `@Module(includes = [GrpcCallContext.Module::class])`. Generating it removes one more hand-written file.
+**Dagger version floor:** `@Subcomponent.Factory` requires Dagger 2.25+ (released 2019). Acceptable for this project.
 
-### 3. What is the generated package for the module and subcomponent?
+---
 
-Options: same package as the annotated handler class(es), a fixed package derived from the root package, or a configurable annotation parameter.
+### Q2 — Generate `GrpcCallScopeGraphModule`
 
-### 4. How are multiple handlers in different packages handled?
+**Decision:** Yes, generate it.
 
-If `HelloWorldService` and `WhateverService` are in different packages, where does the single generated `GrpcHandlersModule` (which references both adapter classes) live?
+**Rationale:** It is always `@Module(includes = [GrpcCallContext.Module::class], subcomponents = [GrpcCallScopeGraph::class])` with no body. Completely mechanical; zero variation across applications. Generating it means users never write or maintain it. The `subcomponents` declaration is what makes `GrpcCallScopeGraph.Factory` injectable in the parent component — the mechanism that eliminates `ApplicationGraphModule`.
 
-### 5. Should `ApplicationGraphModule` (self-binding) be part of the generated output or documented as user-written?
+---
 
-The `ApplicationGraphModule` that binds `ApplicationGraph` as `GrpcCallScopeGraph.Supplier` is currently hand-written. Generating it would require the processor to know about the application component, which it doesn't (and shouldn't). Document as user-written, or find an alternative approach (e.g., `@BindsInstance` on the component builder).
+### Q3 — Require explicit processor option `daggergrpc.package`
+
+**Decision:** The target package for all generated classes is specified via a required processor option. No auto-derivation in the MVP.
+
+- KSP: `ksp { arg("daggergrpc.package", "com.example.armeria.dagger") }`
+- APT: `-Adaggergrpc.package=com.example.armeria.dagger`
+
+If the option is absent, the processor emits a compile error. Auto-derivation from the common ancestor package of annotated classes may be added as a V2 convenience feature.
+
+---
+
+### Q4 — Multi-package handlers: no special case needed
+
+**Decision:** The explicit `daggergrpc.package` option resolves this naturally. Handler and adapter classes are public; cross-package references from the generated classes work without visibility issues.
+
+---
+
+### Q5 — `ApplicationGraphModule` is eliminated
+
+**Decision:** `ApplicationGraphModule` is no longer needed and should not be documented as user-written boilerplate. With `@Subcomponent.Factory`, Dagger automatically provides `GrpcCallScopeGraph.Factory` to the parent component once `GrpcCallScopeGraphModule` (which declares the subcomponent) is included. The user wires exactly one thing: include `GrpcHandlersModule` in their `@Component`.
+
+The existing hand-written `ApplicationGraphModule` in both examples will be deleted as part of T05/T06 once code generation produces the correct output.
+
+---
+
+### Naming — strip `Service` suffix from provision methods
+
+**Decision:** Provision method names on `GrpcCallScopeGraph` are derived from the handler simple class name, lowercased first character, with the `Service` suffix stripped. Provider method names on `GrpcHandlersModule` follow the same base name with `Handler` appended.
+
+- `HelloWorldService` → provision: `helloWorld()`, provider: `helloWorldHandler(...)`
+- `WhateverService` → provision: `whatever()`, provider: `whateverHandler(...)`
+
+---
+
+## Generated Output Golden — Two-Handler Case
+
+Reference handlers: `HelloWorldService` and `WhateverService` in `com.example.armeria.services`.
+Configured package: `com.example.armeria.dagger`.
+
+### Kotlin (KSP output)
+
+**`GrpcCallScopeGraph.kt`**
+```kotlin
+package com.example.armeria.dagger
+
+import com.example.armeria.services.HelloWorldService
+import com.example.armeria.services.WhateverService
+import com.geekinasuit.daggergrpc.api.GrpcCallScope
+import dagger.Subcomponent
+import javax.annotation.Generated
+
+@Generated("com.geekinasuit.daggergrpc.compiler.ksp.DaggerGrpcSymbolProcessor")
+@Subcomponent(modules = [GrpcCallScopeGraphModule::class])
+@GrpcCallScope
+interface GrpcCallScopeGraph {
+  fun helloWorld(): HelloWorldService
+  fun whatever(): WhateverService
+
+  @Subcomponent.Factory
+  interface Factory {
+    fun create(): GrpcCallScopeGraph
+  }
+}
+```
+
+**`GrpcCallScopeGraphModule.kt`**
+```kotlin
+package com.example.armeria.dagger
+
+import com.geekinasuit.daggergrpc.api.GrpcCallContext
+import dagger.Module
+import javax.annotation.Generated
+
+@Generated("com.geekinasuit.daggergrpc.compiler.ksp.DaggerGrpcSymbolProcessor")
+@Module(
+  includes = [GrpcCallContext.Module::class],
+  subcomponents = [GrpcCallScopeGraph::class],
+)
+object GrpcCallScopeGraphModule
+```
+
+**`GrpcHandlersModule.kt`**
+```kotlin
+package com.example.armeria.dagger
+
+import com.example.armeria.services.HelloWorldServiceAdapter
+import com.example.armeria.services.WhateverServiceAdapter
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoSet
+import io.grpc.BindableService
+import javax.annotation.Generated
+
+@Generated("com.geekinasuit.daggergrpc.compiler.ksp.DaggerGrpcSymbolProcessor")
+@Module(includes = [GrpcCallScopeGraphModule::class])
+object GrpcHandlersModule {
+  @Provides @IntoSet
+  fun helloWorldHandler(factory: GrpcCallScopeGraph.Factory): BindableService =
+    HelloWorldServiceAdapter { factory.create().helloWorld() }
+
+  @Provides @IntoSet
+  fun whateverHandler(factory: GrpcCallScopeGraph.Factory): BindableService =
+    WhateverServiceAdapter { factory.create().whatever() }
+}
+```
+
+**User-written `ApplicationGraph.kt` (after T05/T06 — no `ApplicationGraphModule`)**
+```kotlin
+package com.example.armeria.dagger
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import com.example.armeria.ExampleServer
+import dagger.Component
+
+@Component(modules = [GrpcHandlersModule::class])
+@ApplicationScope
+interface ApplicationGraph {
+  fun server(): ExampleServer
+
+  @Component.Builder
+  interface Builder {
+    fun build(): ApplicationGraph
+  }
+
+  companion object {
+    fun builder(): Builder = DaggerApplicationGraph.builder()
+  }
+}
+```
+
+---
+
+### Java (APT output)
+
+**`GrpcCallScopeGraph.java`**
+```java
+package com.example.armeria.dagger;
+
+import com.example.armeria.services.HelloWorldService;
+import com.example.armeria.services.WhateverService;
+import com.geekinasuit.daggergrpc.api.GrpcCallScope;
+import dagger.Subcomponent;
+import javax.annotation.processing.Generated;
+
+@Generated("com.geekinasuit.daggergrpc.compiler.apt.DaggerGrpcAPTProcessor")
+@Subcomponent(modules = {GrpcCallScopeGraphModule.class})
+@GrpcCallScope
+public interface GrpcCallScopeGraph {
+  HelloWorldService helloWorld();
+  WhateverService whatever();
+
+  @Subcomponent.Factory
+  interface Factory {
+    GrpcCallScopeGraph create();
+  }
+}
+```
+
+**`GrpcCallScopeGraphModule.java`**
+```java
+package com.example.armeria.dagger;
+
+import com.geekinasuit.daggergrpc.api.GrpcCallContext;
+import dagger.Module;
+import javax.annotation.processing.Generated;
+
+@Generated("com.geekinasuit.daggergrpc.compiler.apt.DaggerGrpcAPTProcessor")
+@Module(
+  includes = {GrpcCallContext.Module.class},
+  subcomponents = {GrpcCallScopeGraph.class}
+)
+public interface GrpcCallScopeGraphModule {}
+```
+
+**`GrpcHandlersModule.java`**
+```java
+package com.example.armeria.dagger;
+
+import com.example.armeria.services.HelloWorldServiceAdapter;
+import com.example.armeria.services.WhateverServiceAdapter;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoSet;
+import io.grpc.BindableService;
+import javax.annotation.processing.Generated;
+
+@Generated("com.geekinasuit.daggergrpc.compiler.apt.DaggerGrpcAPTProcessor")
+@Module(includes = {GrpcCallScopeGraphModule.class})
+abstract class GrpcHandlersModule {
+  @Provides @IntoSet
+  public static BindableService helloWorldHandler(GrpcCallScopeGraph.Factory factory) {
+    return new HelloWorldServiceAdapter(() -> factory.create().helloWorld());
+  }
+
+  @Provides @IntoSet
+  public static BindableService whateverHandler(GrpcCallScopeGraph.Factory factory) {
+    return new WhateverServiceAdapter(() -> factory.create().whatever());
+  }
+}
+```
+
+**User-written `ApplicationGraph.java` (after T05/T06 — no `ApplicationGraphModule`)**
+```java
+package com.example.armeria.dagger;
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope;
+import com.example.armeria.ExampleServer;
+import dagger.Component;
+
+@Component(modules = {GrpcHandlersModule.class})
+@ApplicationScope
+public interface ApplicationGraph {
+  ExampleServer server();
+
+  @Component.Builder
+  interface Builder {
+    ApplicationGraph build();
+  }
+
+  static ApplicationGraph create() {
+    return DaggerApplicationGraph.create();
+  }
+}
+```
+
+---
 
 ## Acceptance Criteria
 
-- [ ] ADR document written (can be this file, updated, or a separate `thoughts/shared/adr/` entry)
-- [ ] All five questions above answered with a clear decision and rationale
-- [ ] Expected generated output for a two-handler example is written out as a "golden" code snippet (this becomes the test fixture for T05/T06)
-- [ ] T05 and T06 can proceed with a clear spec
+- [x] ADR document written (this file)
+- [x] All five questions answered and confirmed by owner
+- [x] Expected generated output for a two-handler example written as golden code snippets (Kotlin + Java)
+- [x] T05 and T06 can proceed with a clear spec
 
 ## Implementation Notes
 
-- The existing hand-written `GrpcCallScopeGraph.kt` and `GrpcHandlersModule.kt` in `examples/io_grpc/bazel_build_kt/` are the reference starting point.
+- The existing hand-written `GrpcCallScopeGraph`, `GrpcHandlersModule`, `GrpcCallScopeGraphModule`, and `ApplicationGraphModule` in both examples will be deleted as part of T05/T06 and replaced by actually-generated output.
 - The `@Generated("to be generated")` marker on those files was placed intentionally as a breadcrumb.
+- `GrpcCallScopeGraphModule` must declare `subcomponents = [GrpcCallScopeGraph::class]` (Kotlin) / `subcomponents = {GrpcCallScopeGraph.class}` (Java) — this is what makes `GrpcCallScopeGraph.Factory` injectable without any user-written binding module.
+- Dagger version floor for `@Subcomponent.Factory`: 2.25+ (released 2019).

--- a/thoughts/shared/tickets/overview.md
+++ b/thoughts/shared/tickets/overview.md
@@ -11,7 +11,7 @@ T00  Verify HEAD builds & tests          HIGH    ✅ DONE
   └─ T02  Pin Kotlin toolchain           MEDIUM
   └─ T03  Proto version skew             LOW     ✅ DONE
 
-T04  Design module generation shape      HIGH    (prerequisite for T05/T06/T07)
+T04  Design module generation shape      HIGH    ✅ DONE
   └─ T07  Extend ksp-apt-bridge          MEDIUM  (prerequisite for T05/T06)
        └─ T05  KSP module generation     HIGH    (core feature)
        └─ T06  APT module generation     HIGH    (core feature)
@@ -37,7 +37,7 @@ T17  Publish Maven artifacts             MEDIUM  (after stable release tag; coor
 | T01 | Update Kotlin example to canonical Bzlmod names (hygiene) | LOW | infra | open   |
 | T02 | Pin Kotlin toolchain version                  | MEDIUM   | infra        | open   |
 | T03 | Resolve proto version skew                    | LOW      | infra        | done   |
-| T04 | Design generated module shape (ADR)           | HIGH     | codegen      | open   |
+| T04 | Design generated module shape (ADR)           | HIGH     | codegen      | done   |
 | T05 | Implement KSP module generation               | HIGH     | codegen      | open   |
 | T06 | Implement APT module generation               | HIGH     | codegen      | open   |
 | T07 | Extend ksp-apt-bridge for module generation   | MEDIUM   | codegen      | open   |


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary
- Writes the ADR for T04: design of generated module and subcomponent shape, resolving all five open design questions
- Key decision: use `@Subcomponent.Factory` instead of the hand-written `Supplier` interface — eliminates `ApplicationGraphModule` boilerplate entirely; users wire their component by including `GrpcHandlersModule` only
- Requires explicit `daggergrpc.package` processor option (KSP `ksp { arg(...) }` / APT `-A`) for the generated package; no fragile auto-derivation
- Generates `GrpcCallScopeGraphModule` (always trivial: `@Module(includes=[GrpcCallContext.Module], subcomponents=[GrpcCallScopeGraph])`)
- Strips `Service` suffix from provision method names (`HelloWorldService` → `helloWorld()`)
- Includes concrete golden output (Kotlin + Java) for two-handler case — becomes test fixture for T05/T06
- Marks T04 resolved in `thoughts/shared/tickets/overview.md`

## Validation performed
- [ ] N/A — prose/ADR change; no build artifacts affected

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- closes #T04 (thoughts/shared/tickets/T04-design-module-generation.md)

## Rollback
- Revert commit; no side effects
