### PR TITLE
docs: v0.2.0 implementation plan for full module generation

### DIFF
--- a/thoughts/shared/plans/v0.2.0-module-generation.compressed.md
+++ b/thoughts/shared/plans/v0.2.0-module-generation.compressed.md
@@ -100,6 +100,9 @@ write docs/integration-guide.md (Bazel-first; note Gradle/Maven TBD); add link f
   7. wire Armeria server (Set<BindableService> injection + GrpcCallContext.Interceptor)
   8. upgrade notes v0.1.0→v0.2.0: delete hand-written GrpcCallScopeGraph+GrpcCallScopeGraphModule+GrpcHandlersModule+ApplicationGraphModule
 
+§CONSTRAINT Maven-compat
+T18(Gradle examples+Maven artifact pipeline) is post-v0.2.0 follow-on. No step here should preclude building standard Maven-compatible artifact(JAR+POM with correct Maven coordinates) from Bazel. Avoid packaging decisions requiring Bazel-specific conventions incompatible with standard Maven consumers.
+
 §STEP6 tag v0.2.0
 after all PRs merged + CI green:
   gh api repos/geekinasuit/dagger-grpc/git/refs --method POST -f ref=refs/tags/v0.2.0 -f sha=<main-sha>

--- a/thoughts/shared/plans/v0.2.0-module-generation.compressed.md
+++ b/thoughts/shared/plans/v0.2.0-module-generation.compressed.md
@@ -1,0 +1,126 @@
+<!--COMPRESSED v1; source:v0.2.0-module-generation.md-->
+§META
+date:2026-04-22 author:agent tickets:T05,T06,T07,T14,T15 status:active milestone:v0.2.0
+
+§ABBREV
+ts=thoughts/shared ksp=io_grpc/compiler/ksp apt=io_grpc/compiler/apt
+eg-kt=examples/io_grpc/bazel_build_kt eg-java=examples/io_grpc/bazel_build_java
+KP=KotlinPoet JP=JavaPoet HM=HandlerMetadata pkg=daggergrpc.package
+
+§GOAL
+Full generation of GrpcCallScopeGraph+GrpcCallScopeGraphModule+GrpcHandlersModule from both KSP+APT processors; examples updated to use generated output; user integration guide; v0.2.0 tagged.
+v0.1.0 already tagged at pre-generation baseline.
+
+§CONTEXT
+current state:
+  KSP: generates *Adapter.kt correctly; generateModule() stub in module_generator.kt (logs only)
+  APT: generates *Adapter.java correctly; generateModule call commented out in DaggerGrpcAPTProcessor
+  both examples: hand-written GrpcCallScopeGraph+GrpcCallScopeGraphModule+GrpcHandlersModule+ApplicationGraphModule marked @Generated("to be generated")
+  T04 ADR: complete; golden output defined
+
+KSP sequence bug: process() builds lazy Sequence with onEach(generateAdapter); .toList() fires generateAdapter once today(correct, single consumer); passes original sequence to generateModule → re-evaluates when iterated → SECOND generateAdapter call. Second fire NOT triggered(stub doesn't iterate); fix required before T05 makes generateModule iterate.
+
+APT: no sequence bug; elements=List (eager); existing pipeline is correct; only needs generateModule wired in.
+
+HM already provides: name, packageName, adapterName, grpcClass, serviceInterface. Missing: targetPackage (from processor option pkg).
+
+T07 scope: bridge gaps (containingFile, superTypes, etc.) not needed for module generation (only simpleName+qualifiedName+toClassName() used). Expected very thin; driven by gaps discovered during T06. tickets overview lists T07 as prerequisite for T05/T06 but has no actionable pre-work → update overview after T06 confirms no bridge extensions needed.
+
+§APPROACH
+order: fix KSP bug+thread pkg → T05(KSP gen) → T06(APT gen, T07 if needed) → T14(examples) → T15(guide) → v0.2.0 tag
+each step = own PR
+
+§STEPS
+§STEP1 Fix KSP sequence bug + thread pkg (part of T05 PR)
+ksp/DaggerGrpcSymbolProcessor.process():
+  collect sequence → List<HM> before side effects
+  forEach generateAdapter; pass list to generateModule
+  read env.options[pkg]; KSP error + return if absent
+module_generator.kt: change sig → (handlers:List<HM>, targetPackage:String)
+apt/DaggerGrpcAPTProcessor: override getSupportedOptions()=setOf(pkg) [required; else option silently ignored]; override getSupportedSourceVersion()=SourceVersion.latestSupported() [suppresses unclaimed-annotation warnings]; read processingEnv.options[pkg]; error+return if absent
+
+§STEP2 T05: KSP module generation (KotlinPoet)
+implement generateModule in module_generator.kt; generate 3 files into targetPackage:
+
+GrpcCallScopeGraph: @Subcomponent(modules=[GrpcCallScopeGraphModule]) @GrpcCallScope interface
+  provision per handler: name=strip "Service" suffix+lowercase first; returns handler KSClassDeclaration→TypeName
+  nested @Subcomponent.Factory interface Factory { fun create(): GrpcCallScopeGraph }
+  @Generated: use DaggerGrpcSymbolProcessor::class.qualifiedName!! as KotlinPoet addMember() arg(evaluated at codegen time→hardcoded string in output; same pattern as adapterGenerator.kt); actual="com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcSymbolProcessor"(T04 golden corrected)
+
+GrpcCallScopeGraphModule: @Module(includes=[GrpcCallContext.Module], subcomponents=[GrpcCallScopeGraph]) object
+  @Generated(...)
+
+GrpcHandlersModule: @Module(includes=[GrpcCallScopeGraphModule]) object
+  per handler: @Provides @IntoSet fun <name>Handler(factory:GrpcCallScopeGraph.Factory):BindableService = <Adapter>{factory.create().<name>()}
+  @Generated(...)
+
+write via codeGenerator; Dependencies aggregating all handler source files
+
+tests(DaggerGrpcSymbolProcessorTest or new ModuleGeneratorTest):
+  2-handler input → assert golden matches T04 ADR
+  missing pkg option → compile error
+  handler without "Service" suffix (no strip)
+
+§STEP3 T06: APT module generation (JavaPoet)
+add ModuleGenerator class in apt/; mirror AdapterGenerator pattern
+
+GrpcCallScopeGraph: public interface; @Subcomponent(modules={GrpcCallScopeGraphModule.class}) @GrpcCallScope
+  provision per handler (same naming rule); nested @Subcomponent.Factory public interface Factory { GrpcCallScopeGraph create(); }
+  @Generated(DaggerGrpcAPTProcessor.class.getCanonicalName()) [actual="com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcAPTProcessor"]
+
+GrpcCallScopeGraphModule: public interface [per T04 ADR; matches hand-written example; Dagger 2.25+ supports @Module on interfaces]; @Module(includes={GrpcCallContext.Module.class},subcomponents={GrpcCallScopeGraph.class})
+
+GrpcHandlersModule: abstract class; @Module(includes={GrpcCallScopeGraphModule.class})
+  per handler: public static @Provides @IntoSet BindableService <name>Handler(Factory factory) { return new <Adapter>(()->factory.create().<name>()); }
+
+wire into DaggerGrpcAPTProcessor.process():
+  APT already uses List (eager; no sequence bug)
+  uncomment+wire: moduleGenerator.generateModule(handlerMetadatas, targetPackage)
+address T07 bridge gaps if any discovered (expected: none)
+
+tests(DaggerGrpcAPTProcessorTest): same golden assertions Java form; missing option → error
+
+§STEP4 T14: update both examples
+for each of eg-kt and eg-java:
+  delete: GrpcCallScopeGraph.{kt,java} GrpcCallScopeGraphModule.{kt,java} GrpcHandlersModule.{kt,java} ApplicationGraphModule.{kt,java}
+  ApplicationGraph(@Component interface, no method bodies): remove ApplicationGraphModule from @Component(modules=[...]) [safe because generated GrpcHandlersModule injects GrpcCallScopeGraph.Factory not Supplier; Factory injectable via GrpcCallScopeGraphModule.subcomponents — see T04 ADR Q1/Q2]; remove implements/extends GrpcCallScopeGraph.Supplier supertype clause(Supplier gone from generated type); no callScope() body to remove(was in ApplicationGraphModule, deleted)
+  add pkg option to build config:
+    KSP(Bazel): check existing KSP example BUILD.bazel for pluginOptions or equivalent attr; do NOT use Gradle DSL ksp{arg(...)}
+    APT: -Adaggergrpc.package=<pkg> as javacopts on java_library or kt_jvm_library target
+  build each example independently (bin/bazel build //... from example root); both must pass
+
+§STEP5 T15: integration guide
+write docs/integration-guide.md (Bazel-first; note Gradle/Maven TBD); add link from README.md:
+  1. what this library does (1 para)
+  2. prerequisites (Dagger 2.25+, Bazel 8+Bzlmod, Armeria or compatible)
+  3. annotate your handler (@GrpcServiceHandler+@GrpcCallScope+@Inject; GrpcCallContext injection)
+  4. configure processor (KSP Bazel: see example BUILD.bazel for plugin option mechanism | APT: -Adaggergrpc.package=...)
+  5. what gets generated (3 classes, one-liner each)
+  6. wire ApplicationGraph (@Component(modules=[GrpcHandlersModule]); no ApplicationGraphModule needed)
+  7. wire Armeria server (Set<BindableService> injection + GrpcCallContext.Interceptor)
+  8. upgrade notes v0.1.0→v0.2.0: delete hand-written GrpcCallScopeGraph+GrpcCallScopeGraphModule+GrpcHandlersModule+ApplicationGraphModule
+
+§STEP6 tag v0.2.0
+after all PRs merged + CI green:
+  gh api repos/geekinasuit/dagger-grpc/git/refs --method POST -f ref=refs/tags/v0.2.0 -f sha=<main-sha>
+  gh release create lightweight releases for v0.1.0+v0.2.0 with release notes
+  note: BCR(T16)+Maven(T17) publication are separate tickets; these releases are the prerequisite tags only
+
+§RISKS
+KSP Dependencies aggregation wrong→incremental build issues | mirror adapterGenerator.kt; test clean+incremental
+KotlinPoet/JavaPoet cross-package type resolution | use ClassName.bestGuess(md.ast.qualifiedName!!); verify with example build
+Bazel KSP option syntax for pkg | check existing ksp_args in KSP example BUILD.bazel
+APT processingEnv.options key casing | standard -Akey=value; test with Java example
+T08 (KSP tests disabled) | T05 tests use same infra as APT tests for now; link to T08
+v0.2.0 tag lightweight not annotated | gh api POST creates lightweight tag; if T16/T17 require annotated tag revisit via jj git backend
+
+§DONE
+- [ ] both processors generate 3 module files when pkg set
+- [ ] missing pkg → compile error (not silent)
+- [ ] KSP processor tests assert generated output matches T04 golden
+- [ ] APT processor tests assert generated output matches T04 golden
+- [ ] both example projects build from processor output; no hand-written module files
+- [ ] ApplicationGraphModule deleted from both examples; ApplicationGraph simplified
+- [ ] integration guide written + linked from README.md
+- [ ] T07 closed: no-op if no bridge extensions needed | complete if gaps addressed; v0.2.0 cannot tag until T07 closed
+- [ ] v0.2.0 tagged on main

--- a/thoughts/shared/plans/v0.2.0-module-generation.md
+++ b/thoughts/shared/plans/v0.2.0-module-generation.md
@@ -240,6 +240,14 @@ Write `docs/integration-guide.md` covering the following sections, then add a li
    `GrpcCallScopeGraph`, `GrpcCallScopeGraphModule`, `GrpcHandlersModule`, and
    `ApplicationGraphModule`.
 
+## Constraint — Maven Compatibility
+
+Gradle examples and Maven artifact pipeline (T18) are follow-on work, post-v0.2.0.
+No step in this plan should preclude building a standard Maven-compatible artifact from Bazel
+(JAR + POM with correct Maven coordinates). In practice, this means avoiding any packaging
+decisions that would require Bazel-specific conventions incompatible with standard Maven
+consumers.
+
 ### Step 6 — Tag v0.2.0
 
 After all PRs from Steps 1–5 are merged and CI is green on main:
@@ -249,12 +257,6 @@ After all PRs from Steps 1–5 are merged and CI is green on main:
 Note: BCR publication (T16) and Maven artifact publication (T17) are separate tickets with
 their own infrastructure. The releases created here are the prerequisite tags/notes for those
 workflows; do not conflate this step with T16/T17 execution.
-
-Note: Gradle examples and Maven artifact pipeline (T18) are follow-on work, post-v0.2.0.
-**Constraint:** No step in this plan should preclude building a standard Maven-compatible
-artifact from Bazel (JAR + POM with correct Maven coordinates). In practice, this means
-avoiding any packaging decisions that would require Bazel-specific conventions incompatible
-with standard Maven consumers.
 
 ---
 

--- a/thoughts/shared/plans/v0.2.0-module-generation.md
+++ b/thoughts/shared/plans/v0.2.0-module-generation.md
@@ -1,0 +1,279 @@
+---
+date: 2026-04-22
+author: agent
+tickets: T05, T06, T07, T14, T15
+status: active
+milestone: v0.2.0
+---
+
+## Goal
+
+Ship v0.2.0: full generation of `GrpcCallScopeGraph`, `GrpcCallScopeGraphModule`, and
+`GrpcHandlersModule` from both the KSP (Kotlin) and APT (Java) processors, with example
+projects updated to use generated output and a user-facing integration guide.
+
+`v0.1.0` is already tagged at the pre-generation state so users can pin before generated
+files appear and avoid collisions with their hand-written versions.
+
+---
+
+## Context
+
+### What exists today (v0.1.0)
+
+- KSP processor generates `*Adapter.kt` files correctly. `DaggerGrpcSymbolProcessor` already
+  calls `env.generateModule(...)` but the implementation in `module_generator.kt` is a stub
+  (logs only).
+- APT processor generates `*Adapter.java` files correctly. The `generateModule` call is
+  commented out entirely in `DaggerGrpcAPTProcessor`.
+- Both example projects have hand-written `GrpcCallScopeGraph`, `GrpcCallScopeGraphModule`,
+  `GrpcHandlersModule`, and `ApplicationGraphModule` marked `@Generated("to be generated")`.
+- The ADR (T04) is complete: design decisions are confirmed, golden output defined.
+
+### Key bug in KSP processor
+
+`DaggerGrpcSymbolProcessor.process()` builds a lazy `Sequence` with `onEach(generateAdapter)`,
+then calls `.toList()` on it (first evaluation — fires `generateAdapter` once per item), and
+passes the original sequence reference to `generateModule`. Once `generateModule` actually
+iterates the sequence, it will re-evaluate the pipeline and fire `generateAdapter` a second
+time. Note: `generateAdapter` does already fire once today — triggered by the `.toList()` call
+— and currently produces correct output because there is only one consumer. The bug is that
+passing the original sequence to a `generateModule` that actually iterates would add a **second**
+invocation; that second fire is what is not currently triggered (the stub does not iterate). Must be fixed before `generateModule`
+iterates the sequence as part of T05.
+
+### What `HandlerMetadata` already provides
+
+For module generation we need: handler class simple name (for provision method naming),
+adapter class name, handler class type (for provision method return type), and the configured
+package. `HandlerMetadata` has all of these except the configured package, which comes from the
+processor option `daggergrpc.package`.
+
+### T07 bridge scope
+
+The ksp-apt-bridge gaps (`containingFile`, `superTypes`, etc.) are for things adapter
+generation already needed and worked around. For module generation, the APT path needs only
+`simpleName`, `qualifiedName`, and `toClassName()` — all already implemented. T07 is therefore
+expected to be very thin for this milestone; the ticket stays open to be driven by any
+unexpected gaps discovered during T06 implementation.
+
+The tickets overview lists T07 as a prerequisite for T05/T06, but given this analysis T07 has
+no actionable pre-work — it is effectively a no-op for this milestone unless gaps surface
+during T06. The overview dependency should be updated once T06 confirms no bridge extensions
+were needed.
+
+---
+
+## Approach
+
+Implement in this order:
+
+1. **Fix KSP sequence bug + thread `daggergrpc.package` through KSP processor** — small, safe,
+   testable in isolation. Prerequisite for T05.
+2. **T05: KSP module generator** — implement `module_generator.kt` using KotlinPoet, following
+   the same patterns as `adapterGenerator.kt`.
+3. **T06: APT module generator** — implement Java equivalent using JavaPoet, following
+   `AdapterGenerator.kt`. Wire into `DaggerGrpcAPTProcessor`. Address any T07 bridge gaps.
+4. **T14: Update examples** — remove hand-written generated files from both example projects,
+   verify both build end-to-end against actual processor output.
+5. **T15: User-facing integration guide** — write `docs/integration-guide.md` covering the
+   complete wiring story.
+6. **Tag v0.2.0** — after all PRs merged and CI green.
+
+Each step is its own PR (or pair of PRs where T07 bridge work accompanies T06).
+
+---
+
+## Steps
+
+### Step 1 — Fix KSP sequence bug and thread `daggergrpc.package` (part of T05 PR)
+
+In `DaggerGrpcSymbolProcessor.process()`:
+- Collect the sequence to a `List<HandlerMetadata>` before any side effects.
+- Call `generateAdapter` on each item via `forEach`, not `onEach` on the lazy sequence.
+- Pass the list to `generateModule`.
+- Read `daggergrpc.package` from `env.options`; emit a KSP error and return early if absent.
+
+In `module_generator.kt`:
+- Change signature to accept `List<HandlerMetadata>` and `targetPackage: String`.
+
+In `DaggerGrpcAPTProcessor`:
+- Override `getSupportedOptions()` to return `setOf("daggergrpc.package")` — required so APT
+  runners do not silently ignore the option.
+- Override `getSupportedSourceVersion()` to return `SourceVersion.latestSupported()` — suppresses
+  "unclaimed annotation" warnings on modern Java.
+- In `process()`: read `daggergrpc.package` from `processingEnv.options`; emit an error and
+  return if absent.
+
+### Step 2 — T05: KSP module generation
+
+Implement `SymbolProcessorEnvironment.generateModule(handlers, targetPackage)` in
+`module_generator.kt` using KotlinPoet. Generate three files into `targetPackage`:
+
+**`GrpcCallScopeGraph`** — `@Subcomponent @GrpcCallScope` interface:
+- One provision method per handler: name = strip "Service" suffix from simple class name,
+  lowercase first char; return type = the handler `KSClassDeclaration` resolved to a
+  KotlinPoet `TypeName`.
+- Nested `@Subcomponent.Factory interface Factory { fun create(): GrpcCallScopeGraph }`.
+- `@Subcomponent(modules = [GrpcCallScopeGraphModule::class])`.
+- `@Generated` value: use `DaggerGrpcSymbolProcessor::class.qualifiedName!!` as the
+  KotlinPoet `addMember(...)` argument (evaluated at code-generation time, producing a
+  hardcoded string in the generated `.kt` output — the same pattern as `adapterGenerator.kt`).
+  Actual value: `"com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcSymbolProcessor"`.
+  (The T04 ADR golden previously had an incorrect package path — now corrected.)
+
+**`GrpcCallScopeGraphModule`** — `object`:
+- `@Module(includes = [GrpcCallContext.Module::class], subcomponents = [GrpcCallScopeGraph::class])`.
+- `@Generated(...)`.
+
+**`GrpcHandlersModule`** — `object`:
+- `@Module(includes = [GrpcCallScopeGraphModule::class])`.
+- One `@Provides @IntoSet` function per handler:
+  - Name = provision name + "Handler"
+  - Parameter: `factory: GrpcCallScopeGraph.Factory`
+  - Returns `BindableService`
+  - Body: `<AdapterType> { factory.create().<provisionName>() }`
+- `@Generated(...)`.
+
+Write all three files using `codeGenerator` with `Dependencies` aggregating all handler
+source files.
+
+**Tests:** Add to `DaggerGrpcSymbolProcessorTest` (or a new `ModuleGeneratorTest`):
+- Compile a two-handler input; assert generated source matches golden (from T04 ADR).
+- Missing `daggergrpc.package` option → compile error asserted.
+- Single handler case (no "Service" suffix to strip if name doesn't end in "Service").
+
+### Step 3 — T06: APT module generation
+
+Add `ModuleGenerator` class to `io_grpc/compiler/apt/`, mirroring `AdapterGenerator` but
+generating the three module files using JavaPoet.
+
+**`GrpcCallScopeGraph`** — `public interface`:
+- `@Subcomponent(modules = {GrpcCallScopeGraphModule.class}) @GrpcCallScope`.
+- One provision method per handler (same naming rule as KSP).
+- Nested `@Subcomponent.Factory public interface Factory { GrpcCallScopeGraph create(); }`.
+- `@Generated(DaggerGrpcAPTProcessor.class.getCanonicalName())` — use the runtime value;
+  actual value is `"com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcAPTProcessor"`.
+
+**`GrpcCallScopeGraphModule`** — `public interface` (per T04 ADR; matches hand-written example style; Dagger 2.25+ supports `@Module` on interfaces):
+- `@Module(includes = {GrpcCallContext.Module.class}, subcomponents = {GrpcCallScopeGraph.class})`.
+
+**`GrpcHandlersModule`** — `abstract class`:
+- `@Module(includes = {GrpcCallScopeGraphModule.class})`.
+- One `public static @Provides @IntoSet` method per handler.
+- Body: `return new <AdapterType>(() -> factory.create().<provisionName>());`
+
+Wire into `DaggerGrpcAPTProcessor.process()`:
+- The APT processor already collects via `List` operations (eager, no sequence bug).
+- Uncomment the blocked `generateModule` call and wire `targetPackage` through.
+- Pass `handlerMetadatas` and `targetPackage` to `moduleGenerator.generateModule(...)`.
+
+Address any T07 bridge gaps discovered here (expected: none for this scope).
+
+**Tests:** Add to `DaggerGrpcAPTProcessorTest`:
+- Same golden assertions as T05 tests, Java form.
+- Missing option → error asserted.
+
+### Step 4 — T14: Update both example projects
+
+For each of `examples/io_grpc/bazel_build_kt/` and `examples/io_grpc/bazel_build_java/`:
+
+1. Delete the hand-written files:
+   - `GrpcCallScopeGraph.{kt,java}`
+   - `GrpcCallScopeGraphModule.{kt,java}`
+   - `GrpcHandlersModule.{kt,java}`
+   - `ApplicationGraphModule.{kt,java}`
+
+2. Update the `ApplicationGraph` component:
+   - Remove `ApplicationGraphModule` from `@Component(modules=[...])`. It is no longer needed
+     because the generated `GrpcHandlersModule` now injects `GrpcCallScopeGraph.Factory`
+     (not `GrpcCallScopeGraph.Supplier`), and Dagger makes `Factory` automatically injectable
+     once `GrpcCallScopeGraphModule` declares `subcomponents = [GrpcCallScopeGraph::class]`.
+     See T04 ADR Q1/Q2 for the full mechanism.
+   - Remove the `implements GrpcCallScopeGraph.Supplier` / `extends GrpcCallScopeGraph.Supplier`
+     clause (no longer needed — `Supplier` is gone from the generated type).
+   - `ApplicationGraph` is a Dagger `@Component` interface — it has no `callScope()` method
+     body. The actual `callScope()` provision lived in `ApplicationGraphModule`, deleted above.
+   - (No other changes — `GrpcHandlersModule` is still included.)
+
+3. Add `daggergrpc.package` to each example's build config:
+   - KSP (Bazel): check the existing KSP example `BUILD.bazel` for the `pluginOptions` or
+     equivalent attribute used to pass KSP processor args — use that same mechanism. Do not
+     use Gradle DSL (`ksp { arg(...) }`) which is not valid in Bazel.
+   - APT: `-Adaggergrpc.package=<example.dagger.package>` as a `javacopts` entry on the
+     relevant `java_library` or `kt_jvm_library` target.
+
+4. Build each example independently: `bin/bazel build //...` from each example root.
+   Both must pass — this is the integration test for T05+T06.
+
+One PR per example project, or a single PR if both are straightforward.
+
+### Step 5 — T15: User-facing integration guide
+
+Write `docs/integration-guide.md` covering the following sections, then add a link to it from `README.md`:
+
+1. **What this library does** — one paragraph: per-call Dagger scoping for gRPC handlers via
+   annotation processing.
+
+2. **Prerequisites** — Dagger 2.25+, Bazel 8 + Bzlmod (or Maven/Gradle with APT/KSP plugin),
+   Armeria (or compatible gRPC server runtime).
+
+3. **Annotate your handler** — show `@GrpcServiceHandler` + `@GrpcCallScope` on a class,
+   with `@Inject` constructor. Show `GrpcCallContext` injection.
+
+4. **Configure the processor** (Bazel-first; note Gradle/Maven usage TBD):
+   - KSP (Bazel): MODULE.bazel dep + KSP plugin option (see KSP example `BUILD.bazel` for
+     the Bazel-specific mechanism to pass `daggergrpc.package`).
+   - APT (Bazel): MODULE.bazel dep + `-Adaggergrpc.package=...` javacopts.
+
+5. **What gets generated** — list the three generated classes with a one-line description each.
+   Link to the example projects for full context.
+
+6. **Wire your application component** — show the minimal `ApplicationGraph` (`@Component`
+   including `GrpcHandlersModule`, no `ApplicationGraphModule` needed).
+
+7. **Wire the Armeria server** — show injecting `Set<BindableService>` + the
+   `GrpcCallContext.Interceptor` wiring.
+
+8. **Versioning** — note v0.1.0 is the last version with hand-written module files;
+   v0.2.0+ generates them. Users upgrading from v0.1.0 must delete their hand-written
+   `GrpcCallScopeGraph`, `GrpcCallScopeGraphModule`, `GrpcHandlersModule`, and
+   `ApplicationGraphModule`.
+
+### Step 6 — Tag v0.2.0
+
+After all PRs from Steps 1–5 are merged and CI is green on main:
+- `gh api repos/geekinasuit/dagger-grpc/git/refs --method POST -f ref=refs/tags/v0.2.0 -f sha=<main-sha>`
+- Create lightweight GitHub releases for v0.1.0 and v0.2.0 with brief release notes.
+
+Note: BCR publication (T16) and Maven artifact publication (T17) are separate tickets with
+their own infrastructure. The releases created here are the prerequisite tags/notes for those
+workflows; do not conflate this step with T16/T17 execution.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| KSP `Dependencies` aggregation wrong → incremental build issues | Mirror pattern from `adapterGenerator.kt`; test with clean + incremental builds |
+| KotlinPoet / JavaPoet type resolution for handler class in generated package | Use `ClassName.bestGuess(md.ast.qualifiedName!!)` for cross-package refs; verify with example build |
+| Bazel KSP option syntax for `daggergrpc.package` not obvious | Check existing KSP Bazel rules in the KSP example's `BUILD.bazel` for existing `ksp_args` or equivalent |
+| APT `processingEnv.options` key casing | Standard APT options are passed as `-Akey=value`; test with the Java example |
+| T08 (KSP tests disabled) means T05 tests may need kotlin-compile-testing workaround | T05 tests can use the same test infra as current APT tests (compile-testing) for now; link to T08 |
+| v0.2.0 tag is lightweight (not annotated) | `gh api .../git/refs POST` creates a lightweight tag; if T16/T17 require annotated tags, revisit with `git tag -a` via the jj git backend |
+
+---
+
+## Acceptance Criteria (v0.2.0)
+
+- [ ] Both processors generate all three module files when `daggergrpc.package` is set
+- [ ] Missing `daggergrpc.package` → processor emits a compile error (not silent failure)
+- [ ] KSP processor tests assert generated module output matches golden (T04 ADR)
+- [ ] APT processor tests assert generated module output matches golden (T04 ADR)
+- [ ] Both example projects build from processor output with no hand-written module files
+- [ ] `ApplicationGraphModule` deleted from both examples; `ApplicationGraph` simplified
+- [ ] Integration guide written and linked from `README.md`
+- [ ] T07 closed: if no bridge extensions were needed, close it as a no-op; if gaps were
+  found and addressed, close it as complete. v0.2.0 cannot be tagged until T07 is closed.
+- [ ] v0.2.0 tagged on main after all above

--- a/thoughts/shared/plans/v0.2.0-module-generation.md
+++ b/thoughts/shared/plans/v0.2.0-module-generation.md
@@ -250,6 +250,12 @@ Note: BCR publication (T16) and Maven artifact publication (T17) are separate ti
 their own infrastructure. The releases created here are the prerequisite tags/notes for those
 workflows; do not conflate this step with T16/T17 execution.
 
+Note: Gradle examples and Maven artifact pipeline (T18) are follow-on work, post-v0.2.0.
+**Constraint:** No step in this plan should preclude building a standard Maven-compatible
+artifact from Bazel (JAR + POM with correct Maven coordinates). In practice, this means
+avoiding any packaging decisions that would require Bazel-specific conventions incompatible
+with standard Maven consumers.
+
 ---
 
 ## Risks

--- a/thoughts/shared/tickets/T04-design-module-generation.md
+++ b/thoughts/shared/tickets/T04-design-module-generation.md
@@ -89,7 +89,7 @@ import com.geekinasuit.daggergrpc.api.GrpcCallScope
 import dagger.Subcomponent
 import javax.annotation.Generated
 
-@Generated("com.geekinasuit.daggergrpc.compiler.ksp.DaggerGrpcSymbolProcessor")
+@Generated("com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcSymbolProcessor")
 @Subcomponent(modules = [GrpcCallScopeGraphModule::class])
 @GrpcCallScope
 interface GrpcCallScopeGraph {
@@ -111,7 +111,7 @@ import com.geekinasuit.daggergrpc.api.GrpcCallContext
 import dagger.Module
 import javax.annotation.Generated
 
-@Generated("com.geekinasuit.daggergrpc.compiler.ksp.DaggerGrpcSymbolProcessor")
+@Generated("com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcSymbolProcessor")
 @Module(
   includes = [GrpcCallContext.Module::class],
   subcomponents = [GrpcCallScopeGraph::class],
@@ -131,7 +131,7 @@ import dagger.multibindings.IntoSet
 import io.grpc.BindableService
 import javax.annotation.Generated
 
-@Generated("com.geekinasuit.daggergrpc.compiler.ksp.DaggerGrpcSymbolProcessor")
+@Generated("com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcSymbolProcessor")
 @Module(includes = [GrpcCallScopeGraphModule::class])
 object GrpcHandlersModule {
   @Provides @IntoSet
@@ -182,7 +182,7 @@ import com.geekinasuit.daggergrpc.api.GrpcCallScope;
 import dagger.Subcomponent;
 import javax.annotation.processing.Generated;
 
-@Generated("com.geekinasuit.daggergrpc.compiler.apt.DaggerGrpcAPTProcessor")
+@Generated("com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcAPTProcessor")
 @Subcomponent(modules = {GrpcCallScopeGraphModule.class})
 @GrpcCallScope
 public interface GrpcCallScopeGraph {
@@ -204,7 +204,7 @@ import com.geekinasuit.daggergrpc.api.GrpcCallContext;
 import dagger.Module;
 import javax.annotation.processing.Generated;
 
-@Generated("com.geekinasuit.daggergrpc.compiler.apt.DaggerGrpcAPTProcessor")
+@Generated("com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcAPTProcessor")
 @Module(
   includes = {GrpcCallContext.Module.class},
   subcomponents = {GrpcCallScopeGraph.class}
@@ -224,7 +224,7 @@ import dagger.multibindings.IntoSet;
 import io.grpc.BindableService;
 import javax.annotation.processing.Generated;
 
-@Generated("com.geekinasuit.daggergrpc.compiler.apt.DaggerGrpcAPTProcessor")
+@Generated("com.geekinasuit.daggergrpc.iogrpc.compile.DaggerGrpcAPTProcessor")
 @Module(includes = {GrpcCallScopeGraphModule.class})
 abstract class GrpcHandlersModule {
   @Provides @IntoSet

--- a/thoughts/shared/tickets/T18-gradle-examples-maven-artifact.md
+++ b/thoughts/shared/tickets/T18-gradle-examples-maven-artifact.md
@@ -3,6 +3,7 @@ id: T18
 title: Gradle example projects and Maven artifact publication
 priority: medium
 phase: distribution
+milestone: post-v0.2.0
 status: open
 blocked_by: T05, T06
 blocks: ~

--- a/thoughts/shared/tickets/T18-gradle-examples-maven-artifact.md
+++ b/thoughts/shared/tickets/T18-gradle-examples-maven-artifact.md
@@ -5,7 +5,7 @@ priority: medium
 phase: distribution
 milestone: post-v0.2.0
 status: open
-blocked_by: T05, T06
+blocked_by: T05, T06, T15
 blocks: ~
 ---
 

--- a/thoughts/shared/tickets/T18-gradle-examples-maven-artifact.md
+++ b/thoughts/shared/tickets/T18-gradle-examples-maven-artifact.md
@@ -1,0 +1,90 @@
+---
+id: T18
+title: Gradle example projects and Maven artifact publication
+priority: medium
+phase: distribution
+status: open
+blocked_by: T05, T06
+blocks: ~
+---
+
+## Summary
+
+Add Gradle-based example projects (Java/APT and Kotlin/KSP) that consume the library as a
+Maven artifact, and establish the Bazel-to-Maven artifact publication pipeline.
+
+The library itself remains Bazel-built. Maven artifacts are produced from Bazel (using a
+Bazel publication rule or `rules_pkg`), published to a local temporary repository for
+integration testing, and eventually published to Maven Central (coordinate with T17).
+
+## Motivation
+
+Not all users build with Bazel. Gradle is the dominant build tool for JVM projects. Providing
+working Gradle examples with documented wiring is necessary for broad adoption.
+
+## Scope
+
+### Part A — Maven artifact from Bazel
+
+Produce Maven-compatible JARs and POM files from Bazel for:
+- `api/` — the runtime annotations and `GrpcCallContext`
+- `io_grpc/compiler/ksp/` — the KSP annotation processor
+- `io_grpc/compiler/apt/` — the APT annotation processor
+- `util/armeria/` — the Armeria server helper (optional; may be separate artifact)
+
+Use a Bazel rule (e.g., `rules_pkg` or a custom deploy JAR rule) to produce artifacts with
+correct Maven coordinates, `META-INF/MANIFEST.MF`, and a POM. Publish to a local filesystem
+Maven repository for integration testing.
+
+Key requirements:
+- APT processor JAR must include `META-INF/services/javax.annotation.processing.Processor`
+  (already provided by `@AutoService`)
+- KSP processor JAR must include `META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider`
+  (already provided by KSP's service discovery mechanism)
+- POM files must declare the correct runtime vs. compile-only dependency split
+
+### Part B — Gradle example projects
+
+Add two standalone Gradle projects (not composite builds; they consume the artifact):
+
+`examples/io_grpc/gradle_build_java/` — Java, APT:
+- Standard Gradle Java project
+- `repositories { maven { url = uri("...local-repo...") } }`
+- APT processor on `annotationProcessor` configuration
+- `-Adaggergrpc.package=...` via `compileJava.options.compilerArgs`
+- Mirrors the Bazel Java example in structure and handler code
+
+`examples/io_grpc/gradle_build_kt/` — Kotlin, KSP:
+- Standard Gradle Kotlin project with KSP plugin
+- KSP processor on `ksp` configuration
+- `daggergrpc.package` via `ksp { arg("daggergrpc.package", "...") }` in `build.gradle.kts`
+- Mirrors the Bazel Kotlin example in structure and handler code
+
+### Part C — Integration guide update
+
+Update `docs/integration-guide.md` (from T15) to add Gradle sections alongside the existing
+Bazel sections, referencing the new Gradle example projects.
+
+### Part D — Maven Central (coordinate with T17)
+
+Once the local artifact pipeline works, wire it into T17's Maven Central publication flow.
+T17 remains the owner of credentials, release signing, and staging; T18 provides the artifact.
+
+## Acceptance Criteria
+
+- [ ] Bazel produces Maven-compatible JARs + POMs for api, compiler-ksp, compiler-apt
+- [ ] Local Maven repo publication works (`bazel run //:publish-local` or equivalent)
+- [ ] `examples/io_grpc/gradle_build_java/` builds and passes tests consuming from local repo
+- [ ] `examples/io_grpc/gradle_build_kt/` builds and passes tests consuming from local repo
+- [ ] Integration guide updated with Gradle sections
+- [ ] T17 can use T18's artifact pipeline for Maven Central publication
+
+## Implementation Notes
+
+- The `daggergrpc.package` option name is already compatible with both APT (`-Adaggergrpc.package=...`)
+  and KSP Gradle plugin (`ksp { arg("daggergrpc.package", "...") }`).
+- `@AutoService` already handles the APT service file; no manual `META-INF/services` needed.
+- The Gradle examples should be self-contained projects (not composite builds) to accurately
+  reflect how a real user would consume the library.
+- Local repo path can be a `file://` URI pointing to a build output directory, or a fixed
+  temp path like `~/.m2/repository` (standard `mavenLocal()`).

--- a/thoughts/shared/tickets/overview.md
+++ b/thoughts/shared/tickets/overview.md
@@ -27,7 +27,7 @@ T15  User-facing integration guide       LOW     (after T05+T06)
 
 T16  Publish to Bazel Central Registry   MEDIUM  (after stable release tag)
 T17  Publish Maven artifacts             MEDIUM  (after stable release tag; coordinate with T16)
-T18  Gradle examples + Maven artifact    MEDIUM  (after T05+T06; blocked on T17 for Central; see also T15)
+T18  Gradle examples + Maven artifact    MEDIUM  (after T05+T06; Part D coordinates with T17 for Central; see also T15)
 ```
 
 ## Summary Table

--- a/thoughts/shared/tickets/overview.md
+++ b/thoughts/shared/tickets/overview.md
@@ -27,6 +27,7 @@ T15  User-facing integration guide       LOW     (after T05+T06)
 
 T16  Publish to Bazel Central Registry   MEDIUM  (after stable release tag)
 T17  Publish Maven artifacts             MEDIUM  (after stable release tag; coordinate with T16)
+T18  Gradle examples + Maven artifact    MEDIUM  (after T05+T06; blocked on T17 for Central; see also T15)
 ```
 
 ## Summary Table
@@ -51,3 +52,4 @@ T17  Publish Maven artifacts             MEDIUM  (after stable release tag; coor
 | T15 | Write user-facing integration guide           | LOW      | docs         | open   |
 | T16 | Publish to Bazel Central Registry             | MEDIUM   | distribution | open   |
 | T17 | Publish Maven-compatible artifacts            | MEDIUM   | distribution | open   |
+| T18 | Gradle examples and Maven artifact pipeline   | MEDIUM   | distribution | open   |


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary
- Add `thoughts/shared/plans/v0.2.0-module-generation.md`: implementation plan for the v0.2.0 milestone
- Covers T05 (KSP module generation), T06 (APT module generation), T07 (ksp-apt-bridge extensions, expected thin), T14 (example project cleanup), T15 (user-facing integration guide), and v0.2.0 tagging
- Documents the KSP sequence bug fix needed as part of T05 setup
- Specifies the `daggergrpc.package` processor option threading for both processors
- Describes golden-based test approach for both processors
- Includes upgrade guidance for users moving from v0.1.0 (hand-written files to delete)

Note: `v0.1.0` has been tagged on the current main commit, establishing the pre-generation baseline users can pin to.

## Validation performed
- [ ] N/A — prose/plan only

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A (plan document; tickets addressed as plan steps are executed)

## Rollback
- Revert commit; no side effects
