### PR TITLE
feat(T05+T06): implement KSP and APT module generation

### DIFF
--- a/io_grpc/compiler/apt/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/DaggerGrpcAPTProcessor.kt
+++ b/io_grpc/compiler/apt/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/DaggerGrpcAPTProcessor.kt
@@ -8,6 +8,7 @@ import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.Processor
 import javax.annotation.processing.RoundEnvironment
+import javax.lang.model.SourceVersion
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.TypeElement
 
@@ -15,6 +16,10 @@ import javax.lang.model.element.TypeElement
 class DaggerGrpcAPTProcessor : AbstractProcessor() {
   override fun getSupportedAnnotationTypes(): MutableSet<String> =
     mutableSetOf(GrpcServiceHandler::class.java.canonicalName)
+
+  override fun getSupportedOptions(): MutableSet<String> = mutableSetOf("daggergrpc.package")
+
+  override fun getSupportedSourceVersion(): SourceVersion = SourceVersion.latestSupported()
 
   private lateinit var logger: APTLogger
 
@@ -45,9 +50,16 @@ class DaggerGrpcAPTProcessor : AbstractProcessor() {
         .filterNotNull()
         .onEach(adapterGenerator::generateAdapter)
 
-    //    if (handlerMetadatas.toList().isEmpty()) {
-    //      logger.warn("No valid classes were annotated with @GrpcServiceHandler")
-    //    } else env.generateModule(handlerMetadatas)
+    if (handlerMetadatas.isEmpty()) {
+      logger.warn("No valid classes were annotated with @GrpcServiceHandler")
+    } else {
+      val targetPackage = processingEnv.options["daggergrpc.package"]
+      if (targetPackage == null) {
+        logger.warn("daggergrpc.package option not set; skipping module generation")
+      } else {
+        ModuleGenerator(logger, processingEnv.filer).generateModule(handlerMetadatas, targetPackage)
+      }
+    }
     return true
   }
 }

--- a/io_grpc/compiler/apt/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/ModuleGenerator.kt
+++ b/io_grpc/compiler/apt/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/ModuleGenerator.kt
@@ -1,0 +1,118 @@
+package com.geekinasuit.daggergrpc.iogrpc.compile
+
+import com.geekinasuit.kspbridge.apt.APTLogger
+import com.squareup.javapoet.AnnotationSpec
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.JavaFile
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.TypeSpec
+import javax.annotation.processing.Filer
+import javax.annotation.processing.Generated
+import javax.lang.model.element.Modifier
+
+class ModuleGenerator(val logger: APTLogger, val filer: Filer) {
+  fun generateModule(handlers: List<HandlerMetadata>, targetPackage: String) {
+    val graphClassName = ClassName.get(targetPackage, "GrpcCallScopeGraph")
+    val graphModuleClassName = ClassName.get(targetPackage, "GrpcCallScopeGraphModule")
+    val factoryClassName = ClassName.get(targetPackage, "GrpcCallScopeGraph", "Factory")
+    val subcomponentClassName = ClassName.get("dagger", "Subcomponent")
+    val subcomponentFactoryClassName = ClassName.get("dagger", "Subcomponent", "Factory")
+    val moduleClassName = ClassName.get("dagger", "Module")
+    val providesClassName = ClassName.get("dagger", "Provides")
+    val intoSetClassName = ClassName.get("dagger.multibindings", "IntoSet")
+    val bindableServiceClassName = ClassName.get("io.grpc", "BindableService")
+    val grpcCallScopeClassName = ClassName.get("com.geekinasuit.daggergrpc.api", "GrpcCallScope")
+    val grpcCallContextModuleClassName =
+      ClassName.get("com.geekinasuit.daggergrpc.api", "GrpcCallContext", "Module")
+
+    val generatedAnnotation =
+      AnnotationSpec.builder(Generated::class.java)
+        .addMember("value", "\$S", DaggerGrpcAPTProcessor::class.qualifiedName)
+        .build()
+
+    // GrpcCallScopeGraph
+    val factoryInterface =
+      TypeSpec.interfaceBuilder("Factory")
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .addAnnotation(AnnotationSpec.builder(subcomponentFactoryClassName).build())
+        .addMethod(
+          MethodSpec.methodBuilder("create")
+            .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+            .returns(graphClassName)
+            .build()
+        )
+        .build()
+
+    val graphTypeBuilder =
+      TypeSpec.interfaceBuilder("GrpcCallScopeGraph")
+        .addModifiers(Modifier.PUBLIC)
+        .addAnnotation(generatedAnnotation)
+        .addAnnotation(
+          AnnotationSpec.builder(subcomponentClassName)
+            .addMember("modules", "{\$T.class}", graphModuleClassName)
+            .build()
+        )
+        .addAnnotation(AnnotationSpec.builder(grpcCallScopeClassName).build())
+
+    for (md in handlers) {
+      val handlerClassName = ClassName.get(md.packageName, md.name)
+      graphTypeBuilder.addMethod(
+        MethodSpec.methodBuilder(md.provisionName)
+          .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+          .returns(handlerClassName)
+          .build()
+      )
+    }
+    graphTypeBuilder.addType(factoryInterface)
+
+    JavaFile.builder(targetPackage, graphTypeBuilder.build()).build().writeTo(filer)
+
+    // GrpcCallScopeGraphModule
+    JavaFile.builder(
+        targetPackage,
+        TypeSpec.interfaceBuilder("GrpcCallScopeGraphModule")
+          .addModifiers(Modifier.PUBLIC)
+          .addAnnotation(generatedAnnotation)
+          .addAnnotation(
+            AnnotationSpec.builder(moduleClassName)
+              .addMember("includes", "{\$T.class}", grpcCallContextModuleClassName)
+              .addMember("subcomponents", "{\$T.class}", graphClassName)
+              .build()
+          )
+          .build(),
+      )
+      .build()
+      .writeTo(filer)
+
+    // GrpcHandlersModule
+    val handlersModuleBuilder =
+      TypeSpec.classBuilder("GrpcHandlersModule")
+        .addModifiers(Modifier.ABSTRACT)
+        .addAnnotation(generatedAnnotation)
+        .addAnnotation(
+          AnnotationSpec.builder(moduleClassName)
+            .addMember("includes", "{\$T.class}", graphModuleClassName)
+            .build()
+        )
+
+    for (md in handlers) {
+      val adapterClassName = ClassName.get(md.packageName, md.adapterName)
+      handlersModuleBuilder.addMethod(
+        MethodSpec.methodBuilder("${md.provisionName}Handler")
+          .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+          .addAnnotation(AnnotationSpec.builder(providesClassName).build())
+          .addAnnotation(AnnotationSpec.builder(intoSetClassName).build())
+          .addParameter(factoryClassName, "factory")
+          .returns(bindableServiceClassName)
+          .addStatement(
+            "return new \$T(() -> factory.create().\$L())",
+            adapterClassName,
+            md.provisionName,
+          )
+          .build()
+      )
+    }
+
+    JavaFile.builder(targetPackage, handlersModuleBuilder.build()).build().writeTo(filer)
+  }
+}

--- a/io_grpc/compiler/apt/src/test/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/BUILD.bazel
+++ b/io_grpc/compiler/apt/src/test/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/BUILD.bazel
@@ -14,6 +14,8 @@ kt_jvm_test(
     ],
     deps = [
         ":grpc",
+        "//api",
+        "@maven//:com_google_dagger_dagger",
         "@maven//:com_google_testing_compile_compile_testing",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",

--- a/io_grpc/compiler/apt/src/test/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/DaggerGrpcAPTProcessorTest.kt
+++ b/io_grpc/compiler/apt/src/test/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/DaggerGrpcAPTProcessorTest.kt
@@ -74,6 +74,67 @@ class DaggerGrpcAPTProcessorTest {
   }
 
   @Test
+  fun testModuleGeneration() {
+    val src =
+      Source("test.FooService")
+        .withSource(
+          """
+          package test;
+          import com.geekinasuit.daggergrpc.api.GrpcServiceHandler;
+          import foo.Foo.FooRequest;
+          import foo.Foo.FooResponse;
+          import foo.FooServiceGrpc;
+          import io.grpc.stub.StreamObserver;
+          @GrpcServiceHandler(grpcWrapperType = foo.FooServiceGrpc.class)
+          public class FooService implements FooServiceGrpc.AsyncService {
+            @Override
+            public void foo(FooRequest request, StreamObserver<FooResponse> responseObserver) {}
+          }
+          """
+        )
+    val result =
+      javac()
+        .withProcessors(DaggerGrpcAPTProcessor())
+        .withOptions("-Adaggergrpc.package=test.dagger")
+        .compile(src)
+    assertAbout(compilations()).that(result).succeeded()
+    // adapter + GrpcCallScopeGraph + GrpcCallScopeGraphModule + GrpcHandlersModule
+    assertThat(result.generatedSourceFiles()).hasSize(4)
+    val fileNames = result.generatedSourceFiles().map { it.name }
+    assertThat(fileNames).contains("/SOURCE_OUTPUT/test/dagger/GrpcCallScopeGraph.java")
+    assertThat(fileNames).contains("/SOURCE_OUTPUT/test/dagger/GrpcCallScopeGraphModule.java")
+    assertThat(fileNames).contains("/SOURCE_OUTPUT/test/dagger/GrpcHandlersModule.java")
+  }
+
+  @Test
+  fun testMissingPackageOptionWarns() {
+    val src =
+      Source("test.FooService")
+        .withSource(
+          """
+          package test;
+          import com.geekinasuit.daggergrpc.api.GrpcServiceHandler;
+          import foo.Foo.FooRequest;
+          import foo.Foo.FooResponse;
+          import foo.FooServiceGrpc;
+          import io.grpc.stub.StreamObserver;
+          @GrpcServiceHandler(grpcWrapperType = foo.FooServiceGrpc.class)
+          public class FooService implements FooServiceGrpc.AsyncService {
+            @Override
+            public void foo(FooRequest request, StreamObserver<FooResponse> responseObserver) {}
+          }
+          """
+        )
+    val result = javac().withProcessors(DaggerGrpcAPTProcessor()).compile(src)
+    assertAbout(compilations()).that(result).succeeded()
+    // Only the adapter is generated; module generation skipped
+    assertThat(result.generatedSourceFiles()).hasSize(1)
+    assertAbout(compilations())
+      .that(result)
+      .hadWarningContaining("daggergrpc.package")
+  }
+
+  @Test
   fun testValidationFailAnnotationOnInterface() {
     val src =
       Source("test.Source1")

--- a/io_grpc/compiler/common/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/metadata.kt
+++ b/io_grpc/compiler/common/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/metadata.kt
@@ -16,4 +16,7 @@ data class HandlerMetadata(
 
   val adapterName: String
     get() = "${name}Adapter"
+
+  val provisionName: String
+    get() = name.removeSuffix("Service").replaceFirstChar { it.lowercase() }
 }

--- a/io_grpc/compiler/ksp/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/DaggerGrpcSymbolProcessor.kt
+++ b/io_grpc/compiler/ksp/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/DaggerGrpcSymbolProcessor.kt
@@ -20,10 +20,18 @@ class DaggerGrpcSymbolProcessor(private val env: SymbolProcessorEnvironment) : S
         .filterIsInstance<KSClassDeclaration>()
         .map(validator::validate)
         .filterNotNull()
-        .onEach(env::generateAdapter)
-    if (handlerMetadatas.toList().isEmpty()) {
+        .toList()
+    handlerMetadatas.forEach(env::generateAdapter)
+    if (handlerMetadatas.isEmpty()) {
       env.logger.warn("No valid classes were annotated with @GrpcServiceHandler")
-    } else env.generateModule(handlerMetadatas)
+    } else {
+      val targetPackage = env.options["daggergrpc.package"]
+      if (targetPackage == null) {
+        env.logger.warn("daggergrpc.package option not set; skipping module generation")
+      } else {
+        env.generateModule(handlerMetadatas, targetPackage)
+      }
+    }
     return unprocessable
   }
 }

--- a/io_grpc/compiler/ksp/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/module_generator.kt
+++ b/io_grpc/compiler/ksp/src/main/kotlin/com/geekinasuit/daggergrpc/iogrpc/compile/module_generator.kt
@@ -1,8 +1,108 @@
 package com.geekinasuit.daggergrpc.iogrpc.compile
 
+import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+import javax.annotation.processing.Generated
 
-fun SymbolProcessorEnvironment.generateModule(md: Sequence<HandlerMetadata>) {
-  logger.info("Generating GrpcHandler")
-  logger.info(md.toString())
+fun SymbolProcessorEnvironment.generateModule(handlers: List<HandlerMetadata>, targetPackage: String) {
+  val graphClassName = ClassName(targetPackage, "GrpcCallScopeGraph")
+  val graphModuleClassName = ClassName(targetPackage, "GrpcCallScopeGraphModule")
+  val factoryClassName = ClassName(targetPackage, "GrpcCallScopeGraph", "Factory")
+  val subcomponentClassName = ClassName("dagger", "Subcomponent")
+  val subcomponentFactoryClassName = ClassName("dagger", "Subcomponent", "Factory")
+  val moduleClassName = ClassName("dagger", "Module")
+  val providesClassName = ClassName("dagger", "Provides")
+  val intoSetClassName = ClassName("dagger.multibindings", "IntoSet")
+  val bindableServiceClassName = ClassName("io.grpc", "BindableService")
+  val grpcCallScopeClassName = ClassName("com.geekinasuit.daggergrpc.api", "GrpcCallScope")
+  val grpcCallContextModuleClassName =
+    ClassName("com.geekinasuit.daggergrpc.api", "GrpcCallContext", "Module")
+
+  val generatedAnnotation =
+    AnnotationSpec.builder(Generated::class)
+      .addMember("\"${DaggerGrpcSymbolProcessor::class.qualifiedName}\"")
+      .build()
+
+  val dependencies =
+    Dependencies(true, *handlers.mapNotNull { it.ast.containingFile }.toTypedArray())
+
+  // GrpcCallScopeGraph
+  val factoryInterface =
+    TypeSpec.interfaceBuilder("Factory")
+      .addAnnotation(AnnotationSpec.builder(subcomponentFactoryClassName).build())
+      .addFunction(FunSpec.builder("create").returns(graphClassName).build())
+      .build()
+
+  val graphTypeBuilder =
+    TypeSpec.interfaceBuilder("GrpcCallScopeGraph")
+      .addAnnotation(generatedAnnotation)
+      .addAnnotation(
+        AnnotationSpec.builder(subcomponentClassName)
+          .addMember("modules = [%T::class]", graphModuleClassName)
+          .build()
+      )
+      .addAnnotation(AnnotationSpec.builder(grpcCallScopeClassName).build())
+
+  for (md in handlers) {
+    graphTypeBuilder.addFunction(
+      FunSpec.builder(md.provisionName).returns(md.ast.toClassName()).build()
+    )
+  }
+  graphTypeBuilder.addType(factoryInterface)
+
+  FileSpec.builder(targetPackage, "GrpcCallScopeGraph")
+    .addType(graphTypeBuilder.build())
+    .build()
+    .writeTo(codeGenerator, dependencies)
+
+  // GrpcCallScopeGraphModule
+  FileSpec.builder(targetPackage, "GrpcCallScopeGraphModule")
+    .addType(
+      TypeSpec.objectBuilder("GrpcCallScopeGraphModule")
+        .addAnnotation(generatedAnnotation)
+        .addAnnotation(
+          AnnotationSpec.builder(moduleClassName)
+            .addMember("includes = [%T::class]", grpcCallContextModuleClassName)
+            .addMember("subcomponents = [%T::class]", graphClassName)
+            .build()
+        )
+        .build()
+    )
+    .build()
+    .writeTo(codeGenerator, dependencies)
+
+  // GrpcHandlersModule
+  val handlersModuleBuilder =
+    TypeSpec.objectBuilder("GrpcHandlersModule")
+      .addAnnotation(generatedAnnotation)
+      .addAnnotation(
+        AnnotationSpec.builder(moduleClassName)
+          .addMember("includes = [%T::class]", graphModuleClassName)
+          .build()
+      )
+
+  for (md in handlers) {
+    val adapterClassName = ClassName(md.packageName, md.adapterName)
+    handlersModuleBuilder.addFunction(
+      FunSpec.builder("${md.provisionName}Handler")
+        .addAnnotation(AnnotationSpec.builder(providesClassName).build())
+        .addAnnotation(AnnotationSpec.builder(intoSetClassName).build())
+        .addParameter("factory", factoryClassName)
+        .returns(bindableServiceClassName)
+        .addStatement("return %T { factory.create().%L() }", adapterClassName, md.provisionName)
+        .build()
+    )
+  }
+
+  FileSpec.builder(targetPackage, "GrpcHandlersModule")
+    .addType(handlersModuleBuilder.build())
+    .build()
+    .writeTo(codeGenerator, dependencies)
 }


### PR DESCRIPTION
## Summary

- **T05**: Implement KSP module generation using KotlinPoet — generates `GrpcCallScopeGraph`, `GrpcCallScopeGraphModule`, and `GrpcHandlersModule` as Kotlin source files
- **T06**: Implement APT module generation using JavaPoet — mirrors T05 for the Java annotation processing path
- Fix latent KSP sequence bug (lazy `Sequence` passed to `generateModule` would have re-fired `generateAdapter` on second iteration; now eagerly collected to `List` first)
- `daggergrpc.package` option: warns and skips module generation when absent (examples don't set it yet; tightened to error in T14)

## Test plan

- [ ] `bin/bazel build //io_grpc/...` passes
- [ ] `bin/bazel test //io_grpc/compiler/apt/...` passes (4 tests: existing adapter + validation tests, new `testModuleGeneration`, new `testMissingPackageOptionWarns`)
- [ ] KSP test is still a compile-testing stub (T08 prerequisite); no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
